### PR TITLE
Inline exercise logging: accordion cards, AJAX submit, fixed timer bar

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -1,6 +1,8 @@
-from flask import Blueprint, render_template, current_app, redirect, url_for, request, flash, session
+from flask import (Blueprint, render_template, current_app, redirect, url_for,
+                   request, flash, session, jsonify, get_flashed_messages)
 from flask_login import login_required, current_user, login_user, logout_user
 from werkzeug.security import generate_password_hash, check_password_hash
+from sqlalchemy import func
 from app.models import User, Workout, ExerciseLog, UserProgression
 from app import db
 from datetime import datetime, timezone
@@ -9,6 +11,10 @@ main = Blueprint('main', __name__)
 
 MIN_PASSWORD_LENGTH = 8
 MAX_GYM_SETS = 10
+
+
+def _is_ajax():
+    return request.headers.get('X-Requested-With') == 'XMLHttpRequest'
 
 
 @main.route('/')
@@ -22,7 +28,45 @@ def home():
     else:
         routine_data = current_app.config['ROUTINE_DATA']
 
-    return render_template('home.html', routine=routine_data, routine_type=routine)
+    last_logs = {}
+    user_progressions = {}
+    progression_data = {}
+
+    if current_user.is_authenticated:
+        all_names = [ex['name'] for exs in routine_data.values() for ex in exs]
+        subq = (
+            db.session.query(
+                ExerciseLog.exercise_name,
+                func.max(ExerciseLog.id).label('max_id')
+            )
+            .join(Workout)
+            .filter(
+                Workout.user_id == current_user.id,
+                ExerciseLog.exercise_name.in_(all_names)
+            )
+            .group_by(ExerciseLog.exercise_name)
+            .subquery()
+        )
+        last_logs = {
+            log.exercise_name: log
+            for log in ExerciseLog.query.join(subq, ExerciseLog.id == subq.c.max_id).all()
+        }
+
+        if routine == 'bwf':
+            progression_data = current_app.config['PROGRESSION_DATA']
+            user_progressions = {
+                p.exercise_category: p
+                for p in UserProgression.query.filter_by(user_id=current_user.id).all()
+            }
+
+    return render_template(
+        'home.html',
+        routine=routine_data,
+        routine_type=routine,
+        last_logs=last_logs,
+        user_progressions=user_progressions,
+        progression_data=progression_data,
+    )
 
 
 @main.route('/login', methods=['GET', 'POST'])
@@ -73,13 +117,12 @@ def register():
 
         progression_data = current_app.config['PROGRESSION_DATA']
         for category in progression_data:
-            progression = UserProgression(
+            db.session.add(UserProgression(
                 user_id=user.id,
                 exercise_category=category,
                 current_progression=1,
-                current_reps=5
-            )
-            db.session.add(progression)
+                current_reps=5,
+            ))
         db.session.commit()
 
         flash('Registration successful! Please log in.')
@@ -106,37 +149,19 @@ def exercise(section, index):
 def _gym_exercise_view(section, index):
     routine_data = current_app.config['GYM_ROUTINE_DATA']
     exercise_obj = routine_data[section][index]
-
-    last_log = None
-    if current_user.is_authenticated:
-        last_log = (
-            ExerciseLog.query
-            .join(Workout)
-            .filter(
-                Workout.user_id == current_user.id,
-                ExerciseLog.exercise_name == exercise_obj['name']
-            )
-            .order_by(ExerciseLog.id.desc())
-            .first()
-        )
-
     return render_template(
         'exercise.html',
         exercise=exercise_obj,
         section=section,
         routine='gym',
-        rest_period=120,
-        last_log=last_log,
         progression_data=None,
-        user_progression=None
+        user_progression=None,
     )
 
 
 def _bwf_exercise_view(section, index):
     routine_data = current_app.config['ROUTINE_DATA']
     exercise_obj = routine_data[section][index]
-
-    rest_period = 60 if section == 'Core Triplet' else 90
 
     progression_data = None
     if exercise_obj['name'].endswith('Progression'):
@@ -154,10 +179,8 @@ def _bwf_exercise_view(section, index):
         exercise=exercise_obj,
         section=section,
         routine='bwf',
-        rest_period=rest_period,
-        last_log=None,
         progression_data=progression_data,
-        user_progression=user_progression
+        user_progression=user_progression,
     )
 
 
@@ -200,28 +223,40 @@ def end_workout():
 @login_required
 def log_exercise(exercise_name):
     if 'current_workout_id' not in session:
+        if _is_ajax():
+            return jsonify({'status': 'error', 'message': 'No active workout'}), 400
         flash('No active workout. Please start a workout first.')
         return redirect(url_for('main.home'))
 
     workout_id = session['current_workout_id']
     routine = request.form.get('routine', 'bwf')
-    section = request.form.get('section')
+    section = request.form.get('section', '')
     index = request.form.get('index')
+    rest_period = 60 if 'Core' in section else 90
 
     if routine == 'gym':
-        _log_gym_exercise(exercise_name, workout_id)
+        result = _log_gym_exercise(exercise_name, workout_id)
     else:
-        _log_bwf_exercise(exercise_name, workout_id)
+        result = _log_bwf_exercise(exercise_name, workout_id)
+
+    if _is_ajax():
+        get_flashed_messages()  # discard — flash queue unused for AJAX responses
+        return jsonify({
+            'status': 'ok' if result.get('ok') else 'error',
+            'message': result.get('message', ''),
+            'exercise_name': exercise_name,
+            'sets_completed': result.get('sets_completed', 0),
+            'rest_period': rest_period,
+            'advanced': result.get('advanced', False),
+            'new_progression': result.get('new_progression'),
+        })
 
     return redirect(url_for('main.exercise', section=section, index=index, routine=routine))
 
 
 def parse_gym_sets(form):
-    """Collect (weight, reps) pairs from numbered form fields.
-
-    Sets count as completed when reps are filled in; weight is optional
-    so bodyweight exercises (e.g. crunches) log cleanly.
-    """
+    """Return (weights, reps) lists from numbered form fields.
+    A set counts when reps are present; weight is optional."""
     weights, reps = [], []
     for i in range(1, MAX_GYM_SETS + 1):
         reps_str = form.get(f'reps_set_{i}', '').strip()
@@ -234,15 +269,14 @@ def parse_gym_sets(form):
 
 def _log_gym_exercise(exercise_name, workout_id):
     weights, reps = parse_gym_sets(request.form)
-
     if not reps:
         flash('Please fill in at least one set.')
-        return
+        return {'ok': False, 'sets_completed': 0, 'message': 'Please fill in at least one set.'}
 
     has_weights = any(w not in ('', '0') for w in weights)
     weight_unit = request.form.get('weight_unit', 'lbs')
 
-    exercise_log = ExerciseLog(
+    db.session.add(ExerciseLog(
         exercise_name=exercise_name,
         sets_completed=len(reps),
         reps_per_set=','.join(reps),
@@ -250,53 +284,56 @@ def _log_gym_exercise(exercise_name, workout_id):
         weight_unit=weight_unit if has_weights else None,
         progression_level=None,
         notes=request.form.get('notes', ''),
-        workout_id=workout_id
-    )
-    db.session.add(exercise_log)
+        workout_id=workout_id,
+    ))
     db.session.commit()
     flash('Exercise logged!')
+    return {'ok': True, 'sets_completed': len(reps), 'message': 'Exercise logged!'}
 
 
 def _log_bwf_exercise(exercise_name, workout_id):
     progression_level = request.form.get('progression_level', type=int)
-    sets_completed = request.form.get('sets_completed', type=int) or 0
 
     reps_list = []
-    for i in range(1, sets_completed + 1):
-        reps = request.form.get(f'reps_set_{i}', type=int)
-        if reps:
-            reps_list.append(str(reps))
+    for i in range(1, MAX_GYM_SETS + 1):
+        reps_str = request.form.get(f'reps_set_{i}', '').strip()
+        if reps_str:
+            reps_list.append(reps_str)
 
-    exercise_log = ExerciseLog(
+    db.session.add(ExerciseLog(
         exercise_name=exercise_name,
-        sets_completed=sets_completed,
+        sets_completed=len(reps_list),
         reps_per_set=','.join(reps_list),
         progression_level=progression_level,
         notes=request.form.get('notes', ''),
-        workout_id=workout_id
-    )
-    db.session.add(exercise_log)
+        workout_id=workout_id,
+    ))
 
-    maybe_advance_progression(current_user, exercise_name, reps_list)
-
+    advanced, new_name = maybe_advance_progression(current_user, exercise_name, reps_list)
     db.session.commit()
     flash('Exercise logged successfully!')
+    return {
+        'ok': True,
+        'sets_completed': len(reps_list),
+        'message': 'Exercise logged!',
+        'advanced': advanced,
+        'new_progression': new_name,
+    }
 
 
 def maybe_advance_progression(user, exercise_name, reps_list):
-    """Advance the user to the next progression level after hitting
-    3+ sets of 8+ reps, resetting the rep target to 5."""
+    """Advance level after 3+ sets of 8+ reps. Returns (advanced, new_name)."""
     if not exercise_name.endswith('Progression'):
-        return
+        return False, None
     if len(reps_list) < 3 or not all(int(r) >= 8 for r in reps_list):
-        return
+        return False, None
 
     user_progression = UserProgression.query.filter_by(
         user_id=user.id,
         exercise_category=exercise_name
     ).first()
     if not user_progression:
-        return
+        return False, None
 
     progression_data = current_app.config['PROGRESSION_DATA'].get(exercise_name, [])
     max_level = len(progression_data)
@@ -307,6 +344,9 @@ def maybe_advance_progression(user, exercise_name, reps_list):
         user_progression.last_updated = datetime.now(timezone.utc)
         next_name = progression_data[user_progression.current_progression - 1]['name']
         flash(f'Congratulations! You advanced to: {next_name}')
+        return True, next_name
+
+    return False, None
 
 
 @main.route('/progress')
@@ -320,7 +360,7 @@ def progress():
         'progress.html',
         user_progressions=user_progressions,
         progression_data=progression_data,
-        recent_workouts=recent_workouts
+        recent_workouts=recent_workouts,
     )
 
 
@@ -343,5 +383,5 @@ def view_workout(workout_id):
         'workout_detail.html',
         workout=workout,
         exercise_logs=exercise_logs,
-        progression_data=progression_data
+        progression_data=progression_data,
     )

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -630,6 +630,212 @@ footer {
     color: #4a76a8;
 }
 
+/* ── Accordion exercise cards ──────────────────────────────── */
+.exercise-item {
+    margin-bottom: 0.5rem;
+}
+
+.exercise-card-header {
+    display: flex;
+    align-items: center;
+    background-color: white;
+    padding: 0.9rem 1rem;
+    border-radius: 5px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.08);
+    cursor: pointer;
+    user-select: none;
+    -webkit-tap-highlight-color: transparent;
+    text-decoration: none;
+    color: #333;
+}
+
+.exercise-card-header:active {
+    background-color: #f5f5f5;
+}
+
+.exercise-card-main {
+    flex: 1;
+}
+
+.exercise-card-main h3 {
+    font-size: 1.05rem;
+    margin-bottom: 0.25rem;
+}
+
+.exercise-progression-hint,
+.exercise-last-reps {
+    font-size: 0.8rem;
+    color: #888;
+    margin-top: 0.15rem;
+}
+
+.expand-icon {
+    font-size: 1.4rem;
+    color: #aaa;
+    transition: transform 0.2s;
+    line-height: 1;
+    margin-left: 0.5rem;
+}
+
+.expand-icon.open {
+    transform: rotate(90deg);
+}
+
+.nav-arrow {
+    font-size: 1.4rem;
+    color: #ccc;
+    margin-left: 0.5rem;
+}
+
+.logged-badge {
+    display: inline-block;
+    font-size: 0.75rem;
+    font-weight: bold;
+    color: #27ae60;
+    background-color: #eafaf1;
+    border: 1px solid #a9dfbf;
+    border-radius: 3px;
+    padding: 0.1rem 0.45rem;
+    margin-left: 0.5rem;
+    white-space: nowrap;
+}
+
+.exercise-panel {
+    background-color: #f9f9f9;
+    border: 1px solid #e8e8e8;
+    border-top: none;
+    border-radius: 0 0 5px 5px;
+    padding: 1rem;
+    margin-bottom: 0.25rem;
+}
+
+.progression-info {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.75rem;
+    padding: 0.5rem 0.75rem;
+    background-color: #e8f0f8;
+    border-radius: 4px;
+    font-size: 0.9rem;
+}
+
+.progression-level {
+    color: #888;
+    font-size: 0.8rem;
+}
+
+.form-error {
+    color: #c0392b;
+    font-size: 0.85rem;
+    min-height: 1.1rem;
+    margin-bottom: 0.5rem;
+}
+
+.btn.full-width {
+    width: 100%;
+    margin-top: 0.5rem;
+    padding: 0.8rem;
+    font-size: 1rem;
+}
+
+/* ── Bottom timer bar ───────────────────────────────────────── */
+.timer-bar {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background-color: #2c3e50;
+    color: white;
+    padding: 0.7rem 1rem;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    z-index: 200;
+    box-shadow: 0 -2px 8px rgba(0,0,0,0.25);
+}
+
+.timer-bar-left {
+    display: flex;
+    flex-direction: column;
+    gap: 0.1rem;
+    min-width: 0;
+}
+
+.timer-exercise {
+    font-size: 0.75rem;
+    color: #aab7c4;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 140px;
+}
+
+.timer-bar-display {
+    font-size: 1.5rem;
+    font-weight: bold;
+    font-variant-numeric: tabular-nums;
+    line-height: 1;
+}
+
+.timer-bar-controls {
+    display: flex;
+    gap: 0.4rem;
+}
+
+.timer-ctrl-btn {
+    background-color: rgba(255,255,255,0.1);
+    border: 1px solid rgba(255,255,255,0.2);
+    color: white;
+    padding: 0.4rem 0.7rem;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.85rem;
+    white-space: nowrap;
+}
+
+.timer-ctrl-btn.primary {
+    background-color: #4a76a8;
+    border-color: #4a76a8;
+    padding: 0.4rem 1rem;
+    font-size: 1rem;
+}
+
+body.timer-visible main {
+    padding-bottom: 80px;
+}
+
+/* ── Advancement banner ─────────────────────────────────────── */
+.advancement-banner {
+    background-color: #27ae60;
+    color: white;
+    padding: 0.75rem 1rem;
+    border-radius: 5px;
+    margin-bottom: 1rem;
+    text-align: center;
+    font-weight: bold;
+}
+
+/* ── log-hint on exercise detail ────────────────────────────── */
+.log-hint {
+    margin-top: 1.5rem;
+    padding: 0.75rem;
+    background-color: #f0f4f8;
+    border-radius: 5px;
+    font-size: 0.9rem;
+    color: #555;
+}
+
+.log-hint a {
+    color: #4a76a8;
+}
+
+.progression-next {
+    margin-top: 0.5rem;
+    font-size: 0.85rem;
+    color: #666;
+}
+
 /* ── Mobile responsive ─────────────────────────────────────── */
 @media (max-width: 600px) {
 

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -1,139 +1,268 @@
-// Shared front-end behaviour. Each block guards on its root element so this
-// file can load safely on every page.
+document.addEventListener('DOMContentLoaded', function () {
+    'use strict';
 
-document.addEventListener('DOMContentLoaded', function() {
+    // ── Constants ──────────────────────────────────────────────────
+    const LBS_PER_KG = 2.20462;
 
-    // ── Rest Timer ──────────────────────────────────────────────
-    const timerSection = document.querySelector('.timer-section');
-    if (timerSection) {
-        const timerDisplay = timerSection.querySelector('.timer-display');
-        const startBtn = document.getElementById('timer-start');
-        const resetBtn = document.getElementById('timer-reset');
-        const defaultTime = parseInt(timerSection.dataset.restPeriod, 10) || 90;
+    // ── Unit state ─────────────────────────────────────────────────
+    let currentUnit = localStorage.getItem('weightUnit') || 'lbs';
 
-        let countdown;
-        let timeLeft = defaultTime;
-        let isRunning = false;
+    // ── Timer state ────────────────────────────────────────────────
+    let timerSeconds = 0;
+    let timerInterval = null;
+    let timerRunning = false;
+    let timerRestPeriod = 90;
 
-        function updateTimerDisplay() {
-            const m = Math.floor(timeLeft / 60);
-            const s = timeLeft % 60;
-            timerDisplay.textContent = `${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
+    // ── Card accordion ─────────────────────────────────────────────
+    let openCardId = null;
+
+    document.addEventListener('click', function (e) {
+        const header = e.target.closest('.exercise-card-header');
+        if (!header) return;
+        if (header.dataset.card) {
+            toggleCard(header.dataset.card);
+        } else if (header.dataset.href) {
+            window.location.href = header.dataset.href;
+        }
+    });
+
+    document.addEventListener('keydown', function (e) {
+        if (e.key !== 'Enter' && e.key !== ' ') return;
+        const header = e.target.closest('.exercise-card-header');
+        if (!header) return;
+        e.preventDefault();
+        if (header.dataset.card) {
+            toggleCard(header.dataset.card);
+        } else if (header.dataset.href) {
+            window.location.href = header.dataset.href;
+        }
+    });
+
+    function toggleCard(cardId) {
+        const panel = document.getElementById('panel-' + cardId);
+        if (!panel) return;
+
+        if (openCardId && openCardId !== cardId) {
+            collapseCard(openCardId);
         }
 
-        function startTimer() {
-            if (isRunning) return;
-            isRunning = true;
-            startBtn.textContent = 'Pause';
-            countdown = setInterval(() => {
-                timeLeft--;
-                updateTimerDisplay();
-                if (timeLeft <= 0) {
-                    clearInterval(countdown);
-                    timerDisplay.textContent = 'DONE!';
-                    startBtn.textContent = 'Start';
-                    isRunning = false;
-                    if ('vibrate' in navigator) navigator.vibrate([200, 100, 200]);
-                }
-            }, 1000);
+        if (!panel.hidden) {
+            collapseCard(cardId);
+        } else {
+            expandCard(cardId);
         }
-
-        startBtn.addEventListener('click', function() {
-            if (isRunning) {
-                clearInterval(countdown);
-                isRunning = false;
-                startBtn.textContent = 'Resume';
-            } else {
-                startTimer();
-            }
-        });
-
-        resetBtn.addEventListener('click', function() {
-            clearInterval(countdown);
-            isRunning = false;
-            startBtn.textContent = 'Start';
-            timeLeft = defaultTime;
-            updateTimerDisplay();
-        });
-
-        [['timer-60', 60], ['timer-90', 90], ['timer-120', 120]].forEach(function([id, secs]) {
-            const btn = document.getElementById(id);
-            if (btn) btn.addEventListener('click', () => { timeLeft = secs; updateTimerDisplay(); });
-        });
-
-        updateTimerDisplay();
     }
 
-    // ── BWF dynamic rep inputs ───────────────────────────────────
-    window.updateRepInputs = function(sets) {
-        const container = document.getElementById('rep-inputs');
-        if (!container) return;
-        const defaultReps = container.dataset.defaultReps || '5';
-        container.innerHTML = '';
-        for (let i = 1; i <= sets; i++) {
-            container.innerHTML += `
-                <div class="form-group">
-                    <label for="reps_set_${i}">Reps (Set ${i})</label>
-                    <input type="number" id="reps_set_${i}" name="reps_set_${i}" min="1" max="20" value="${defaultReps}">
-                </div>`;
+    function expandCard(cardId) {
+        const panel = document.getElementById('panel-' + cardId);
+        if (!panel) return;
+        panel.hidden = false;
+        openCardId = cardId;
+        setExpandIcon(cardId, true);
+        syncUnitInPanel(panel);
+    }
+
+    function collapseCard(cardId) {
+        const panel = document.getElementById('panel-' + cardId);
+        if (panel) panel.hidden = true;
+        if (openCardId === cardId) openCardId = null;
+        setExpandIcon(cardId, false);
+    }
+
+    function setExpandIcon(cardId, isOpen) {
+        const header = document.querySelector('.exercise-card-header[data-card="' + cardId + '"]');
+        if (!header) return;
+        const icon = header.querySelector('.expand-icon');
+        if (icon) icon.classList.toggle('open', isOpen);
+    }
+
+    // ── AJAX form submit ───────────────────────────────────────────
+    document.addEventListener('submit', function (e) {
+        const form = e.target;
+        if (!form.classList.contains('exercise-log-form')) return;
+        e.preventDefault();
+
+        const btn = form.querySelector('[type="submit"]');
+        if (btn) btn.disabled = true;
+
+        const errDiv = form.querySelector('.form-error');
+        if (errDiv) errDiv.textContent = '';
+
+        fetch(form.action, {
+            method: 'POST',
+            headers: { 'X-Requested-With': 'XMLHttpRequest' },
+            body: new FormData(form),
+        })
+            .then(function (r) { return r.json(); })
+            .then(function (data) {
+                if (btn) btn.disabled = false;
+                if (data.status === 'ok') {
+                    const cardId = form.dataset.cardId;
+                    markCardDone(cardId, data.sets_completed);
+                    collapseCard(cardId);
+                    startTimer(data.rest_period, data.exercise_name);
+                    if (data.advanced && data.new_progression) {
+                        showAdvancementBanner(data.new_progression);
+                    }
+                } else {
+                    if (errDiv) errDiv.textContent = data.message || 'Error logging exercise.';
+                }
+            })
+            .catch(function () {
+                if (btn) btn.disabled = false;
+                form.submit();
+            });
+    });
+
+    function markCardDone(cardId, setsCompleted) {
+        const header = document.querySelector('.exercise-card-header[data-card="' + cardId + '"]');
+        if (!header) return;
+        let badge = header.querySelector('.logged-badge');
+        if (!badge) {
+            badge = document.createElement('span');
+            badge.className = 'logged-badge';
+            header.appendChild(badge);
+        }
+        badge.textContent = '✓ ' + setsCompleted + (setsCompleted === 1 ? ' set' : ' sets');
+    }
+
+    function showAdvancementBanner(newProgression) {
+        const banner = document.createElement('div');
+        banner.className = 'advancement-banner';
+        banner.textContent = 'Advanced to: ' + newProgression;
+        const main = document.querySelector('main');
+        if (main) main.insertAdjacentElement('afterbegin', banner);
+        setTimeout(function () { banner.remove(); }, 5000);
+    }
+
+    // ── Timer ──────────────────────────────────────────────────────
+    function startTimer(restPeriod, exerciseName) {
+        timerRestPeriod = restPeriod || 90;
+        timerSeconds = timerRestPeriod;
+        clearInterval(timerInterval);
+        timerRunning = true;
+
+        const bar = document.getElementById('timer-bar');
+        if (bar) bar.hidden = false;
+        document.body.classList.add('timer-visible');
+
+        const label = document.getElementById('timer-exercise');
+        if (label) label.textContent = exerciseName || '';
+
+        const toggleBtn = document.getElementById('timer-bar-toggle');
+        if (toggleBtn) toggleBtn.textContent = '⏸';
+
+        updateTimerDisplay();
+        timerInterval = setInterval(timerTick, 1000);
+    }
+
+    function timerTick() {
+        if (timerSeconds > 0) {
+            timerSeconds--;
+            updateTimerDisplay();
+        } else {
+            clearInterval(timerInterval);
+            timerRunning = false;
+            const disp = document.getElementById('timer-bar-display');
+            if (disp) disp.textContent = 'REST ✓';
+            const btn = document.getElementById('timer-bar-toggle');
+            if (btn) btn.textContent = '▶';
+            if (navigator.vibrate) navigator.vibrate([200, 100, 200]);
+        }
+    }
+
+    function updateTimerDisplay() {
+        const m = Math.floor(timerSeconds / 60);
+        const s = timerSeconds % 60;
+        const disp = document.getElementById('timer-bar-display');
+        if (disp) disp.textContent = pad2(m) + ':' + pad2(s);
+    }
+
+    function pad2(n) { return String(n).padStart(2, '0'); }
+
+    window.timerToggle = function () {
+        if (timerRunning) {
+            clearInterval(timerInterval);
+            timerRunning = false;
+            const btn = document.getElementById('timer-bar-toggle');
+            if (btn) btn.textContent = '▶';
+        } else {
+            timerRunning = true;
+            const btn = document.getElementById('timer-bar-toggle');
+            if (btn) btn.textContent = '⏸';
+            timerInterval = setInterval(timerTick, 1000);
         }
     };
 
-    // ── Gym kg/lbs unit toggle ───────────────────────────────────
-    const unitInput = document.getElementById('weight-unit-input');
-    if (!unitInput) return; // not a weighted gym exercise page
+    window.timerAdjust = function (delta) {
+        timerSeconds = Math.max(0, timerSeconds + delta);
+        updateTimerDisplay();
+    };
 
-    const LBS_PER_KG = 2.20462;
-    let currentUnit = localStorage.getItem('weightUnit') || 'lbs';
+    window.timerReset = function () {
+        clearInterval(timerInterval);
+        timerRunning = false;
+        timerSeconds = timerRestPeriod;
+        updateTimerDisplay();
+        const btn = document.getElementById('timer-bar-toggle');
+        if (btn) btn.textContent = '▶';
+    };
 
+    // ── Unit conversion ────────────────────────────────────────────
     function convertWeight(value, from, to) {
         if (from === to) return value;
         return from === 'lbs' ? value / LBS_PER_KG : value * LBS_PER_KG;
     }
 
-    function roundWeight(value) {
-        return Math.round(value * 2) / 2; // nearest 0.5
-    }
+    function roundWeight(v) { return Math.round(v * 2) / 2; }
 
-    window.setUnit = function(unit) {
+    window.setUnit = function (unit) {
         if (unit === currentUnit) return;
-
-        document.querySelectorAll('.weight-input').forEach(function(input) {
+        document.querySelectorAll('.weight-input').forEach(function (input) {
             const v = parseFloat(input.value);
             if (!isNaN(v) && v > 0) {
                 input.value = roundWeight(convertWeight(v, currentUnit, unit));
             }
         });
-
         currentUnit = unit;
         localStorage.setItem('weightUnit', currentUnit);
-        applyUnitUI();
+        applyUnitUI(document);
     };
 
-    function applyUnitUI() {
-        unitInput.value = currentUnit;
-
-        document.querySelectorAll('.unit-display').forEach(el => el.textContent = currentUnit);
-
-        const btnLbs = document.getElementById('btn-lbs');
-        const btnKg = document.getElementById('btn-kg');
-        if (btnLbs) btnLbs.classList.toggle('active', currentUnit === 'lbs');
-        if (btnKg) btnKg.classList.toggle('active', currentUnit === 'kg');
-
-        document.querySelectorAll('.last-set-badge').forEach(function(badge) {
-            const storedUnit = badge.dataset.storedUnit || 'lbs';
+    function applyUnitUI(root) {
+        root = root || document;
+        root.querySelectorAll('.weight-unit-input').forEach(function (el) {
+            el.value = currentUnit;
+        });
+        root.querySelectorAll('.unit-display').forEach(function (el) {
+            el.textContent = currentUnit;
+        });
+        document.querySelectorAll('.unit-toggle-btn').forEach(function (btn) {
+            btn.classList.toggle('active', btn.dataset.unit === currentUnit);
+        });
+        root.querySelectorAll('.last-set-badge').forEach(function (badge) {
             const weightDisplay = badge.querySelector('.last-weight-display');
             const unitLabel = badge.querySelector('.last-unit-label');
             if (!weightDisplay || !unitLabel) return;
             const rawValue = parseFloat(badge.dataset.lbsValue);
+            const storedUnit = badge.dataset.storedUnit || 'lbs';
             if (isNaN(rawValue)) return;
             weightDisplay.textContent = roundWeight(convertWeight(rawValue, storedUnit, currentUnit));
             unitLabel.textContent = currentUnit;
         });
     }
 
-    // Convert pre-filled weights to the saved unit preference on load
-    document.querySelectorAll('.weight-input').forEach(function(input) {
+    function syncUnitInPanel(panel) {
+        panel.querySelectorAll('.weight-unit-input').forEach(function (el) {
+            el.value = currentUnit;
+        });
+        panel.querySelectorAll('.unit-display').forEach(function (el) {
+            el.textContent = currentUnit;
+        });
+    }
+
+    // Convert pre-filled weight inputs from stored unit to current preference
+    document.querySelectorAll('.weight-input').forEach(function (input) {
         const storedValue = parseFloat(input.dataset.storedValue);
         const storedUnit = input.dataset.storedUnit || 'lbs';
         if (!isNaN(storedValue) && storedValue > 0) {
@@ -141,5 +270,5 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     });
 
-    applyUnitUI();
+    applyUnitUI(document);
 });

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="csrf-token" content="{{ csrf_token() }}">
     <title>{% block title %}BWF Routine App{% endblock %}</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
     {% block extra_css %}{% endblock %}

--- a/app/templates/exercise.html
+++ b/app/templates/exercise.html
@@ -14,12 +14,6 @@
             <h3>Reps</h3>
             <p>{{ exercise.reps }}</p>
         </div>
-        {% if rest_period %}
-        <div class="info-card">
-            <h3>Rest</h3>
-            <p>{{ rest_period }}s</p>
-        </div>
-        {% endif %}
     </div>
 
     <div class="exercise-description">
@@ -27,163 +21,36 @@
         <p>{{ exercise.description }}</p>
     </div>
 
-    {# ── GYM exercise logging form ── #}
-    {% if routine == 'gym' %}
-
-        {% if current_user.is_authenticated %}
-            {% if not session.get('current_workout_id') %}
-            <div class="log-exercise-form">
-                <p class="no-workout-msg">Start a workout to log this exercise.</p>
-                <a href="{{ url_for('main.start_workout', routine_type='gym') }}" class="btn primary">Start Gym Workout</a>
-            </div>
-            {% else %}
-
-            {% set num_sets = exercise.sets|int %}
-            {% set last_weights = last_log.weight_per_set.split(',') if last_log and last_log.weight_per_set else [] %}
-            {% set last_reps = last_log.reps_per_set.split(',') if last_log and last_log.reps_per_set else [] %}
-            {% set last_unit = last_log.weight_unit if last_log and last_log.weight_unit else 'lbs' %}
-
-            <div class="log-exercise-form">
-                <h3>Log This Exercise</h3>
-
-                {% if last_log %}
-                <div class="last-session-summary">
-                    <span class="last-session-label">Last session:</span>
-                    {% for i in range(last_reps|length) %}
-                    <span class="last-set-badge"
-                          data-lbs-value="{{ last_weights[i] if i < last_weights|length else '' }}"
-                          data-stored-unit="{{ last_unit }}">
-                        {% if i < last_weights|length and last_weights[i] != '0' %}
-                        <span class="last-weight-display">{{ last_weights[i] }}</span>
-                        <span class="last-unit-label">{{ last_unit }}</span> ×
-                        {% endif %}
-                        {{ last_reps[i] }} reps
-                    </span>
-                    {% endfor %}
-                </div>
-                {% endif %}
-
-                {% if exercise.weighted %}
-                <div class="unit-toggle">
-                    <span class="unit-toggle-label">Unit:</span>
-                    <button type="button" id="btn-lbs" class="unit-toggle-btn" onclick="setUnit('lbs')">lbs</button>
-                    <button type="button" id="btn-kg" class="unit-toggle-btn" onclick="setUnit('kg')">kg</button>
-                </div>
-                {% endif %}
-
-                <form method="POST" action="{{ url_for('main.log_exercise', exercise_name=exercise.name) }}">
-                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                    <input type="hidden" name="section" value="{{ section }}">
-                    <input type="hidden" name="index" value="{{ request.view_args.index }}">
-                    <input type="hidden" name="routine" value="{{ routine }}">
-                    <input type="hidden" name="weight_unit" id="weight-unit-input" value="lbs">
-
-                    {% for i in range(1, num_sets + 1) %}
-                    <div class="set-row">
-                        <span class="set-label">Set {{ i }}</span>
-                        <div class="set-inputs">
-                            {% if exercise.weighted %}
-                            <div class="form-group">
-                                <label>Weight (<span class="unit-display">lbs</span>)</label>
-                                <input type="number"
-                                       class="weight-input"
-                                       name="weight_set_{{ i }}"
-                                       id="weight_set_{{ i }}"
-                                       step="0.5" min="0"
-                                       data-stored-value="{{ last_weights[i-1] if last_weights|length >= i else '' }}"
-                                       data-stored-unit="{{ last_unit }}"
-                                       value="{{ last_weights[i-1] if last_weights|length >= i else '' }}">
-                            </div>
-                            {% endif %}
-                            <div class="form-group">
-                                <label>Reps</label>
-                                <input type="number"
-                                       name="reps_set_{{ i }}"
-                                       id="reps_set_{{ i }}"
-                                       min="1" max="100"
-                                       value="{{ last_reps[i-1] if last_reps|length >= i else '' }}">
-                            </div>
-                        </div>
-                    </div>
-                    {% endfor %}
-
-                    <div class="form-group">
-                        <label for="notes">Notes</label>
-                        <textarea id="notes" name="notes" rows="2"></textarea>
-                    </div>
-
-                    <button type="submit" class="btn primary">Log Exercise</button>
-                </form>
-            </div>
-            {% endif %}
-        {% else %}
-        <p class="login-prompt"><a href="{{ url_for('main.login') }}">Log in</a> to track your progress.</p>
-        {% endif %}
-
-    {# ── BWF progression logging form ── #}
-    {% elif progression_data and user_progression %}
+    {% if progression_data and user_progression %}
+    {% set current_level = user_progression.current_progression %}
+    {% set current_prog = progression_data[current_level - 1] %}
     <div class="progression-section">
         <h3>Your Current Progression</h3>
-        {% set current_level = user_progression.current_progression %}
-        {% set current_exercise = progression_data|selectattr('level', 'eq', current_level)|first %}
-
         <div class="current-progression">
-            <h4>{{ current_exercise.name }} (Level {{ current_level }})</h4>
-            <p>{{ current_exercise.description }}</p>
+            <h4>{{ current_prog.name }} (Level {{ current_level }}/{{ progression_data|length }})</h4>
+            <p>{{ current_prog.description }}</p>
             <p class="progression-goal">Goal: 3 sets of 8 reps with good form</p>
-            <p class="progression-current">Current: 3 sets of {{ user_progression.current_reps }} reps</p>
+            <p class="progression-current">Current target: 3 × {{ user_progression.current_reps }} reps</p>
         </div>
-
-        {% if current_user.is_authenticated %}
-        <div class="log-exercise-form">
-            <h3>Log Your Progress</h3>
-            <form method="POST" action="{{ url_for('main.log_exercise', exercise_name=exercise.name) }}">
-                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                <input type="hidden" name="section" value="{{ section }}">
-                <input type="hidden" name="index" value="{{ request.view_args.index }}">
-                <input type="hidden" name="routine" value="{{ routine }}">
-                <input type="hidden" name="progression_level" value="{{ current_level }}">
-
-                <div class="form-group">
-                    <label for="sets_completed">Sets Completed</label>
-                    <select id="sets_completed" name="sets_completed" onchange="updateRepInputs(this.value)">
-                        <option value="1">1</option>
-                        <option value="2">2</option>
-                        <option value="3" selected>3</option>
-                    </select>
-                </div>
-
-                <div id="rep-inputs" data-default-reps="{{ user_progression.current_reps }}">
-                    {% for i in range(1, 4) %}
-                    <div class="form-group">
-                        <label for="reps_set_{{ i }}">Reps (Set {{ i }})</label>
-                        <input type="number" id="reps_set_{{ i }}" name="reps_set_{{ i }}" min="1" max="20" value="{{ user_progression.current_reps }}">
-                    </div>
-                    {% endfor %}
-                </div>
-
-                <div class="form-group">
-                    <label for="notes">Notes</label>
-                    <textarea id="notes" name="notes" rows="3"></textarea>
-                </div>
-
-                <button type="submit" class="btn primary">Log Exercise</button>
-            </form>
-        </div>
+        {% if progression_data|length > current_level %}
+        {% set next_prog = progression_data[current_level] %}
+        <p class="progression-next">Next: {{ next_prog.name }}</p>
         {% endif %}
+    </div>
+    {% elif progression_data %}
+    <div class="progression-section">
+        <h3>Progressions</h3>
+        {% for level in progression_data %}
+        <div class="current-progression">
+            <h4>Level {{ level.level }}: {{ level.name }}</h4>
+            <p>{{ level.description }}</p>
+        </div>
+        {% endfor %}
     </div>
     {% endif %}
 
-    <div class="timer-section" data-rest-period="{{ rest_period or 90 }}">
-        <h3>Rest Timer</h3>
-        <div class="timer-display">00:00</div>
-        <div class="timer-controls">
-            <button id="timer-60" class="timer-btn">60s</button>
-            <button id="timer-90" class="timer-btn">90s</button>
-            <button id="timer-120" class="timer-btn">2min</button>
-            <button id="timer-start" class="timer-btn primary">Start</button>
-            <button id="timer-reset" class="timer-btn">Reset</button>
-        </div>
-    </div>
+    {% if session.get('current_workout_id') %}
+    <p class="log-hint">Log this exercise by expanding its card on the <a href="{{ url_for('main.home', routine=routine) }}">home page</a>.</p>
+    {% endif %}
 </div>
 {% endblock %}

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -1,51 +1,215 @@
 {% extends "base.html" %}
-{% block title %}{% if routine_type == 'gym' %}Gym Routine{% else %}BWF Routine{% endif %} - Home{% endblock %}
+{% block title %}{% if routine_type == 'gym' %}Gym Routine{% else %}BWF Routine{% endif %}{% endblock %}
 {% block content %}
 <div class="routine-container">
 
     <div class="routine-tabs">
         <a href="{{ url_for('main.home', routine='bwf') }}"
-           class="routine-tab {% if routine_type == 'bwf' %}active{% endif %}">BWF Routine</a>
+           class="routine-tab {% if routine_type == 'bwf' %}active{% endif %}">BWF</a>
         <a href="{{ url_for('main.home', routine='gym') }}"
-           class="routine-tab {% if routine_type == 'gym' %}active{% endif %}">Gym Routine</a>
+           class="routine-tab {% if routine_type == 'gym' %}active{% endif %}">Gym</a>
     </div>
 
     {% if current_user.is_authenticated %}
         {% if session.get('current_workout_id') %}
-            <div class="active-workout-banner">
-                <p>Workout in progress! Don't forget to log your exercises.</p>
-            </div>
+        <div class="active-workout-banner">
+            Workout in progress — tap an exercise to log it.
+        </div>
         {% else %}
-            <div class="start-workout-cta">
-                <a href="{{ url_for('main.start_workout', routine_type=routine_type) }}" class="btn primary">
-                    Start {% if routine_type == 'gym' %}Gym{% else %}BWF{% endif %} Workout
-                </a>
-            </div>
+        <div class="start-workout-cta">
+            <a href="{{ url_for('main.start_workout', routine_type=routine_type) }}" class="btn primary">
+                Start {% if routine_type == 'gym' %}Gym{% else %}BWF{% endif %} Workout
+            </a>
+        </div>
         {% endif %}
     {% endif %}
 
     {% for section, exercises in routine.items() %}
-        <section class="routine-section">
-            <h2>{{ section }}</h2>
-            <ul class="exercise-list">
-                {% for exercise in exercises %}
-                <li>
-                    <a href="{{ url_for('main.exercise', section=section, index=loop.index0, routine=routine_type) }}"
-                       class="exercise-card">
+    {% set section_i = loop.index0 %}
+    <section class="routine-section">
+        <h2>{{ section }}</h2>
+        <ul class="exercise-list">
+            {% for exercise in exercises %}
+            {% set ex_i = loop.index0 %}
+            {% set card_id = section_i|string ~ '_' ~ ex_i|string %}
+            {% set last_log = last_logs.get(exercise.name) %}
+            {% set is_warmup = section == 'Warm-up' %}
+            {% set workout_active = session.get('current_workout_id') %}
+            {% set can_log = current_user.is_authenticated and workout_active and not is_warmup %}
+
+            <li class="exercise-item">
+                <div class="exercise-card-header"
+                     data-href="{{ url_for('main.exercise', section=section, index=ex_i, routine=routine_type) }}"
+                     {% if can_log %}data-card="{{ card_id }}"{% endif %}
+                     role="button" tabindex="0">
+                    <div class="exercise-card-main">
                         <h3>{{ exercise.name }}</h3>
                         <div class="exercise-meta">
-                            <span>{{ exercise.sets }} sets</span>
-                            <span>{{ exercise.reps }} reps</span>
+                            <span>{{ exercise.sets }}×{{ exercise.reps }}</span>
                             {% if exercise.get('weighted') %}
                             <span class="weighted-badge">weighted</span>
                             {% endif %}
                         </div>
-                    </a>
-                </li>
-                {% endfor %}
-            </ul>
-        </section>
+
+                        {# Compact last-session preview (BWF: progression name) #}
+                        {% if routine_type == 'bwf' and exercise.name in user_progressions %}
+                        {% set up = user_progressions[exercise.name] %}
+                        {% set pl = progression_data.get(exercise.name, []) %}
+                        {% if pl %}
+                        <div class="exercise-progression-hint">
+                            {{ pl[up.current_progression - 1].name }}
+                        </div>
+                        {% endif %}
+                        {% elif last_log and last_log.reps_per_set %}
+                        <div class="exercise-last-reps">{{ last_log.reps_per_set }} reps</div>
+                        {% endif %}
+                    </div>
+                    <span class="expand-icon {% if can_log %}{% else %}nav-arrow{% endif %}">›</span>
+                </div>
+
+                {% if can_log %}
+                <div class="exercise-panel" id="panel-{{ card_id }}" hidden>
+
+                    {% if routine_type == 'gym' %}
+                    {# ── Gym inline form ── #}
+                    {% set last_weights = last_log.weight_per_set.split(',') if last_log and last_log.weight_per_set else [] %}
+                    {% set last_reps_list = last_log.reps_per_set.split(',') if last_log and last_log.reps_per_set else [] %}
+                    {% set last_unit = last_log.weight_unit if last_log and last_log.weight_unit else 'lbs' %}
+                    {% set num_sets = exercise.sets|int %}
+
+                    {% if last_log %}
+                    <div class="last-session-summary">
+                        <span class="last-session-label">Last session</span>
+                        {% for r_i in range(last_reps_list|length) %}
+                        <span class="last-set-badge"
+                              data-lbs-value="{{ last_weights[r_i] if r_i < last_weights|length else '' }}"
+                              data-stored-unit="{{ last_unit }}">
+                            {% if r_i < last_weights|length and last_weights[r_i] != '0' %}
+                            <span class="last-weight-display">{{ last_weights[r_i] }}</span>
+                            <span class="last-unit-label">{{ last_unit }}</span> ×
+                            {% endif %}
+                            {{ last_reps_list[r_i] }} reps
+                        </span>
+                        {% endfor %}
+                    </div>
+                    {% endif %}
+
+                    {% if exercise.weighted %}
+                    <div class="unit-toggle">
+                        <span class="unit-toggle-label">Unit:</span>
+                        <button type="button" class="unit-toggle-btn" data-unit="lbs" onclick="setUnit('lbs')">lbs</button>
+                        <button type="button" class="unit-toggle-btn" data-unit="kg" onclick="setUnit('kg')">kg</button>
+                    </div>
+                    {% endif %}
+
+                    <form class="exercise-log-form" method="POST"
+                          action="{{ url_for('main.log_exercise', exercise_name=exercise.name) }}"
+                          data-card-id="{{ card_id }}">
+                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                        <input type="hidden" name="section" value="{{ section }}">
+                        <input type="hidden" name="index" value="{{ ex_i }}">
+                        <input type="hidden" name="routine" value="{{ routine_type }}">
+                        {% if exercise.weighted %}
+                        <input type="hidden" class="weight-unit-input" name="weight_unit" value="lbs">
+                        {% endif %}
+
+                        {% for i in range(1, num_sets + 1) %}
+                        <div class="set-row">
+                            <span class="set-label">Set {{ i }}</span>
+                            <div class="set-inputs">
+                                {% if exercise.weighted %}
+                                <div class="form-group">
+                                    <label>Weight (<span class="unit-display">lbs</span>)</label>
+                                    <input type="number" class="weight-input"
+                                           name="weight_set_{{ i }}"
+                                           step="0.5" min="0"
+                                           data-stored-value="{{ last_weights[i-1] if last_weights|length >= i else '' }}"
+                                           data-stored-unit="{{ last_unit }}"
+                                           value="{{ last_weights[i-1] if last_weights|length >= i else '' }}">
+                                </div>
+                                {% endif %}
+                                <div class="form-group">
+                                    <label>Reps</label>
+                                    <input type="number" name="reps_set_{{ i }}"
+                                           min="1" max="100"
+                                           value="{{ last_reps_list[i-1] if last_reps_list|length >= i else '' }}">
+                                </div>
+                            </div>
+                        </div>
+                        {% endfor %}
+
+                        <div class="form-error"></div>
+                        <button type="submit" class="btn primary full-width">Log Exercise</button>
+                    </form>
+
+                    {% else %}
+                    {# ── BWF inline form ── #}
+                    {% set user_prog = user_progressions.get(exercise.name) %}
+                    {% set prog_list = progression_data.get(exercise.name, []) %}
+                    {% set default_reps = user_prog.current_reps if user_prog else 5 %}
+                    {% set num_sets = exercise.sets|int %}
+
+                    {% if user_prog and prog_list %}
+                    {% set current_prog = prog_list[user_prog.current_progression - 1] %}
+                    <div class="progression-info">
+                        <strong>{{ current_prog.name }}</strong>
+                        <span class="progression-level">Level {{ user_prog.current_progression }}/{{ prog_list|length }}</span>
+                    </div>
+                    {% endif %}
+
+                    <form class="exercise-log-form" method="POST"
+                          action="{{ url_for('main.log_exercise', exercise_name=exercise.name) }}"
+                          data-card-id="{{ card_id }}">
+                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                        <input type="hidden" name="section" value="{{ section }}">
+                        <input type="hidden" name="index" value="{{ ex_i }}">
+                        <input type="hidden" name="routine" value="{{ routine_type }}">
+                        {% if user_prog %}
+                        <input type="hidden" name="progression_level" value="{{ user_prog.current_progression }}">
+                        {% endif %}
+
+                        {% for i in range(1, num_sets + 1) %}
+                        <div class="set-row">
+                            <span class="set-label">Set {{ i }}</span>
+                            <div class="set-inputs">
+                                <div class="form-group">
+                                    <label>Reps</label>
+                                    <input type="number" name="reps_set_{{ i }}"
+                                           min="1" max="30" value="{{ default_reps }}">
+                                </div>
+                            </div>
+                        </div>
+                        {% endfor %}
+
+                        <div class="form-error"></div>
+                        <button type="submit" class="btn primary full-width">Log Exercise</button>
+                    </form>
+                    {% endif %}
+
+                </div>
+                {% endif %}
+
+            </li>
+            {% endfor %}
+        </ul>
+    </section>
     {% endfor %}
 
 </div>
+
+{% if current_user.is_authenticated and session.get('current_workout_id') %}
+<div id="timer-bar" class="timer-bar" hidden>
+    <div class="timer-bar-left">
+        <span id="timer-exercise" class="timer-exercise"></span>
+        <span id="timer-bar-display" class="timer-bar-display">00:00</span>
+    </div>
+    <div class="timer-bar-controls">
+        <button class="timer-ctrl-btn" onclick="timerAdjust(-30)">−30s</button>
+        <button id="timer-bar-toggle" class="timer-ctrl-btn primary" onclick="timerToggle()">▶</button>
+        <button class="timer-ctrl-btn" onclick="timerAdjust(30)">+30s</button>
+        <button class="timer-ctrl-btn" onclick="timerReset()">↺</button>
+    </div>
+</div>
+{% endif %}
+
 {% endblock %}

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -101,7 +101,7 @@ def test_workout_detail_blocked_for_other_users(logged_in_client, app):
     assert b'do not have permission' in resp.data
 
 
-def test_gym_exercise_page_prefills_last_log(logged_in_client):
+def test_home_page_prefills_last_gym_log(logged_in_client):
     client = logged_in_client
     client.get('/start_workout?routine_type=gym')
     client.post('/log_exercise/Bench Press', data={
@@ -110,7 +110,7 @@ def test_gym_exercise_page_prefills_last_log(logged_in_client):
         'weight_set_1': '105', 'reps_set_1': '9',
     })
 
-    resp = client.get('/exercise/Push/0?routine=gym')
+    resp = client.get('/?routine=gym')
     assert resp.status_code == 200
     assert b'Last session' in resp.data
     assert b'105' in resp.data


### PR DESCRIPTION
- home.html: exercise cards expand inline during a workout — one card open at a time, gym/BWF forms rendered server-side with last-session pre-fill; warm-up section remains navigation-only
- exercise.html: stripped to info-only (description + progression levels); logging forms removed
- main.js: full rewrite — delegated accordion toggle, AJAX form submit with JSON response handling, fixed bottom timer bar (auto-starts on log, −30s/▶⏸/+30s/↺ controls), kg/lbs unit conversion preserved
- style.css: accordion card, exercise panel, logged-badge, bottom timer-bar, advancement-banner styles; body.timer-visible adds padding-bottom so content clears the bar
- routes.py: _is_ajax() helper, log_exercise returns JSON for AJAX, get_flashed_messages() drains queue on AJAX path, home() loads last_logs via single func.max subquery + user_progressions dict
- base.html: csrf-token meta tag for potential header-based CSRF
- tests: test_gym_exercise_page_prefills_last_log → checks home page

https://claude.ai/code/session_01189RwwfCxdMZtNQysXgmsY