### PR TITLE
Inline workout logging, interactive weight pickers, and per-user routine editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,10 @@ A mobile-friendly workout tracker built with Flask. Supports two routines:
 
 ## Features
 
+- **Quickstart** — the app opens to your last-used routine with a one-tap "Start Workout" button
 - **Workout sessions** — start a workout, log exercises as you go, end when done (empty workouts are discarded)
+- **Routine editing (Gym)** — add your own exercises (name, sets, reps, equipment) or remove built-in ones, right from the home page; removals are restorable
+- **Flexible sets** — add or remove sets on any logging form (1–10), for light days and crazy days alike
 - **Progression system (BWF)** — hit 3 sets of 8+ reps and the app advances you to the next exercise progression automatically
 - **Weight tracking (Gym)** — log weight × reps per set; your last session's numbers are pre-filled the next time
 - **kg/lbs toggle** — switch units on the fly for machines labelled differently; preference is remembered, conversions apply to inputs and your last-session summary

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A mobile-friendly workout tracker built with Flask. Supports two routines:
 - **Progression system (BWF)** — hit 3 sets of 8+ reps and the app advances you to the next exercise progression automatically
 - **Weight tracking (Gym)** — log weight × reps per set; your last session's numbers are pre-filled the next time
 - **kg/lbs toggle** — switch units on the fly for machines labelled differently; preference is remembered, conversions apply to inputs and your last-session summary
+- **Plate calculator (barbell exercises)** — tap plates to load a visual barbell, see the total including the bar, and fill it into any set with one tap; plate denominations follow the kg/lbs toggle
 - **Rest timer** — built-in 60/90/120s countdown with vibration on completion
 - **Progress page** — current progression levels and recent workout history with per-set details
 - **Mobile-first UI** — responsive layout designed to be used at the gym from a phone

--- a/app/models.py
+++ b/app/models.py
@@ -54,6 +54,39 @@ class ExerciseLog(db.Model):
         return [float(w) for w in self.weight_per_set.split(',') if w]
 
 
+class CustomExercise(db.Model):
+    """A user-added exercise overlaid on the built-in routine."""
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'))
+    routine_type = db.Column(db.String(20), default='gym')
+    section = db.Column(db.String(50))
+    name = db.Column(db.String(100))
+    sets = db.Column(db.Integer, default=3)
+    reps = db.Column(db.String(20), default='8-12')
+    weighted = db.Column(db.Boolean, default=True)
+    equipment = db.Column(db.String(20), default='machine')
+    description = db.Column(db.Text, default='')
+
+    def to_dict(self):
+        return {
+            'name': self.name,
+            'sets': str(self.sets),
+            'reps': self.reps,
+            'weighted': self.weighted,
+            'equipment': self.equipment,
+            'description': self.description or '',
+            'custom': True,
+        }
+
+
+class HiddenExercise(db.Model):
+    """A built-in exercise the user removed from their routine view."""
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'))
+    routine_type = db.Column(db.String(20), default='gym')
+    exercise_name = db.Column(db.String(100))
+
+
 class UserProgression(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     user_id = db.Column(db.Integer, db.ForeignKey('user.id'))

--- a/app/routes.py
+++ b/app/routes.py
@@ -3,7 +3,8 @@ from flask import (Blueprint, render_template, current_app, redirect, url_for,
 from flask_login import login_required, current_user, login_user, logout_user
 from werkzeug.security import generate_password_hash, check_password_hash
 from sqlalchemy import func
-from app.models import User, Workout, ExerciseLog, UserProgression
+from app.models import (User, Workout, ExerciseLog, UserProgression,
+                         CustomExercise, HiddenExercise)
 from app import db
 from datetime import datetime, timezone
 
@@ -11,20 +12,64 @@ main = Blueprint('main', __name__)
 
 MIN_PASSWORD_LENGTH = 8
 MAX_GYM_SETS = 10
+ALLOWED_EQUIPMENT = ('barbell', 'dumbbell', 'machine', 'bodyweight')
 
 
 def _is_ajax():
     return request.headers.get('X-Requested-With') == 'XMLHttpRequest'
 
 
+def _gym_routine_for_user():
+    """Built-in gym routine with the user's removals and additions applied."""
+    base = current_app.config['GYM_ROUTINE_DATA']
+    if not current_user.is_authenticated:
+        return base
+
+    hidden = {
+        h.exercise_name
+        for h in HiddenExercise.query.filter_by(
+            user_id=current_user.id, routine_type='gym')
+    }
+    customs = CustomExercise.query.filter_by(
+        user_id=current_user.id, routine_type='gym').all()
+
+    routine = {
+        section: [ex for ex in exercises if ex['name'] not in hidden]
+        for section, exercises in base.items()
+    }
+    for custom in customs:
+        routine.setdefault(custom.section, []).append(custom.to_dict())
+    return routine
+
+
+def _default_routine_view():
+    """Last routine the user interacted with, falling back to bwf."""
+    if not current_user.is_authenticated:
+        return 'bwf'
+    view = session.get('current_routine_view')
+    if view in ('bwf', 'gym'):
+        return view
+    last_workout = (Workout.query.filter_by(user_id=current_user.id)
+                    .order_by(Workout.id.desc()).first())
+    if last_workout and last_workout.routine_type in ('bwf', 'gym'):
+        return last_workout.routine_type
+    return 'bwf'
+
+
 @main.route('/')
 def home():
-    routine = request.args.get('routine', 'bwf')
+    routine = request.args.get('routine')
+    if routine not in ('bwf', 'gym'):
+        routine = _default_routine_view()
     if current_user.is_authenticated:
         session['current_routine_view'] = routine
 
+    hidden_count = 0
     if routine == 'gym':
-        routine_data = current_app.config['GYM_ROUTINE_DATA']
+        routine_data = _gym_routine_for_user()
+        if current_user.is_authenticated:
+            hidden_count = HiddenExercise.query.filter_by(
+                user_id=current_user.id, routine_type='gym').count()
     else:
         routine_data = current_app.config['ROUTINE_DATA']
 
@@ -66,6 +111,7 @@ def home():
         last_logs=last_logs,
         user_progressions=user_progressions,
         progression_data=progression_data,
+        hidden_count=hidden_count,
     )
 
 
@@ -147,8 +193,12 @@ def exercise(section, index):
 
 
 def _gym_exercise_view(section, index):
-    routine_data = current_app.config['GYM_ROUTINE_DATA']
-    exercise_obj = routine_data[section][index]
+    routine_data = _gym_routine_for_user()
+    exercises = routine_data.get(section, [])
+    if index >= len(exercises):
+        flash('Exercise not found.')
+        return redirect(url_for('main.home', routine='gym'))
+    exercise_obj = exercises[index]
     return render_template(
         'exercise.html',
         exercise=exercise_obj,
@@ -184,6 +234,84 @@ def _bwf_exercise_view(section, index):
     )
 
 
+@main.route('/routine/add_exercise', methods=['POST'])
+@login_required
+def add_exercise():
+    section = request.form.get('section', '').strip()
+    name = request.form.get('name', '').strip()
+
+    if not name or section not in current_app.config['GYM_ROUTINE_DATA']:
+        flash('Exercise name and a valid section are required.')
+        return redirect(url_for('main.home', routine='gym'))
+
+    visible_names = {
+        ex['name'].lower()
+        for exercises in _gym_routine_for_user().values()
+        for ex in exercises
+    }
+    if name.lower() in visible_names:
+        flash(f'"{name}" is already in your routine.')
+        return redirect(url_for('main.home', routine='gym'))
+
+    sets = request.form.get('sets', type=int) or 3
+    sets = max(1, min(sets, MAX_GYM_SETS))
+    reps = request.form.get('reps', '').strip() or '8-12'
+    equipment = request.form.get('equipment', 'machine')
+    if equipment not in ALLOWED_EQUIPMENT:
+        equipment = 'machine'
+
+    db.session.add(CustomExercise(
+        user_id=current_user.id,
+        routine_type='gym',
+        section=section,
+        name=name,
+        sets=sets,
+        reps=reps[:20],
+        weighted=(equipment != 'bodyweight'),
+        equipment=equipment,
+        description=request.form.get('description', '').strip(),
+    ))
+    db.session.commit()
+    flash(f'Added "{name}" to {section}.')
+    return redirect(url_for('main.home', routine='gym'))
+
+
+@main.route('/routine/remove_exercise', methods=['POST'])
+@login_required
+def remove_exercise():
+    name = request.form.get('name', '').strip()
+    if not name:
+        return redirect(url_for('main.home', routine='gym'))
+
+    custom = CustomExercise.query.filter_by(
+        user_id=current_user.id, routine_type='gym', name=name).first()
+    if custom:
+        db.session.delete(custom)
+    else:
+        already_hidden = HiddenExercise.query.filter_by(
+            user_id=current_user.id, routine_type='gym',
+            exercise_name=name).first()
+        if not already_hidden:
+            db.session.add(HiddenExercise(
+                user_id=current_user.id,
+                routine_type='gym',
+                exercise_name=name,
+            ))
+    db.session.commit()
+    flash(f'Removed "{name}" from your routine.')
+    return redirect(url_for('main.home', routine='gym'))
+
+
+@main.route('/routine/restore_exercises', methods=['POST'])
+@login_required
+def restore_exercises():
+    HiddenExercise.query.filter_by(
+        user_id=current_user.id, routine_type='gym').delete()
+    db.session.commit()
+    flash('Removed exercises restored.')
+    return redirect(url_for('main.home', routine='gym'))
+
+
 @main.route('/start_workout')
 @login_required
 def start_workout():
@@ -194,6 +322,7 @@ def start_workout():
 
     session['current_workout_id'] = workout.id
     session['current_routine_type'] = routine_type
+    session['current_routine_view'] = routine_type
 
     flash('Workout started!')
     return redirect(url_for('main.home', routine=routine_type))

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -739,6 +739,151 @@ footer {
     font-size: 1rem;
 }
 
+/* ── Plate picker ───────────────────────────────────────────── */
+.plate-picker {
+    background-color: white;
+    border: 1px solid #e0e6ec;
+    border-radius: 6px;
+    padding: 0.75rem;
+    margin-bottom: 1rem;
+}
+
+.plate-picker-header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    margin-bottom: 0.5rem;
+}
+
+.plate-picker-title {
+    font-size: 0.8rem;
+    font-weight: bold;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: #888;
+}
+
+.plate-total {
+    font-size: 1.2rem;
+    font-weight: bold;
+    color: #4a76a8;
+    font-variant-numeric: tabular-nums;
+}
+
+.barbell-visual {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 90px;
+    background-color: #f4f7fa;
+    border-radius: 5px;
+    padding: 0.5rem 0.25rem;
+    margin-bottom: 0.6rem;
+    overflow-x: auto;
+}
+
+.bv-bar {
+    width: 90px;
+    min-width: 50px;
+    height: 8px;
+    background: linear-gradient(#b8c2cc, #8f9aa5);
+    border-radius: 2px;
+    flex-shrink: 1;
+}
+
+.bv-side {
+    display: flex;
+    align-items: center;
+    gap: 2px;
+}
+
+.bv-plate {
+    border: none;
+    border-radius: 3px;
+    padding: 0;
+    cursor: pointer;
+    box-shadow: inset -2px 0 3px rgba(0,0,0,0.25);
+    flex-shrink: 0;
+}
+
+.bv-plate:active {
+    opacity: 0.7;
+}
+
+.bv-hint {
+    position: absolute;
+    bottom: 4px;
+    left: 0;
+    right: 0;
+    text-align: center;
+    font-size: 0.72rem;
+    color: #a5b1bd;
+    pointer-events: none;
+}
+
+.plate-buttons {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+    margin-bottom: 0.6rem;
+}
+
+.plate-add-btn {
+    background-color: white;
+    border: 2px solid #7f8c8d;
+    border-radius: 50%;
+    width: 46px;
+    height: 46px;
+    font-size: 0.85rem;
+    font-weight: bold;
+    color: #333;
+    cursor: pointer;
+    flex-shrink: 0;
+}
+
+.plate-add-btn:active {
+    transform: scale(0.92);
+}
+
+.plate-apply {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.4rem;
+}
+
+.plate-apply-label {
+    font-size: 0.8rem;
+    color: #888;
+    font-weight: bold;
+}
+
+.plate-apply-btn,
+.plate-clear-btn {
+    background-color: #e8f0f8;
+    border: 1px solid #c8d8e8;
+    color: #4a76a8;
+    border-radius: 4px;
+    padding: 0.35rem 0.7rem;
+    font-size: 0.85rem;
+    font-weight: bold;
+    cursor: pointer;
+}
+
+.plate-apply-btn.applied {
+    background-color: #27ae60;
+    border-color: #27ae60;
+    color: white;
+}
+
+.plate-clear-btn {
+    background-color: #f5f5f5;
+    border-color: #ddd;
+    color: #888;
+    margin-left: auto;
+}
+
 /* ── Bottom timer bar ───────────────────────────────────────── */
 .timer-bar {
     position: fixed;

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1059,12 +1059,15 @@ footer {
     font-size: 1rem;
 }
 
-/* Dumbbell weight grid */
+/* Dumbbell weight chips — single scrollable row */
 .db-steps {
     display: flex;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
+    overflow-x: auto;
     gap: 0.35rem;
     margin-bottom: 0.5rem;
+    padding-bottom: 0.25rem;
+    -webkit-overflow-scrolling: touch;
 }
 
 .db-step-btn {
@@ -1085,31 +1088,137 @@ footer {
 }
 .db-step-btn:active { transform: scale(0.94); }
 
-/* Machine stepper */
-.machine-stepper {
+/* Dumbbell visual rack */
+.dumbbell-visual {
     display: flex;
     align-items: center;
-    gap: 0.5rem;
-    margin-bottom: 0.25rem;
+    justify-content: center;
+    gap: 0.75rem;
+    background-color: #f4f7fa;
+    border-radius: 5px;
+    padding: 0.6rem 0.5rem 1.6rem;
+    margin-bottom: 0.6rem;
 }
 
-.stepper-btn {
-    background-color: #f5f5f5;
-    border: 1px solid #ddd;
-    color: #333;
-    border-radius: 4px;
-    padding: 0.4rem 0.8rem;
+.db-arrow {
+    background-color: white;
+    border: 2px solid #c8d8e8;
+    color: #4a76a8;
+    border-radius: 50%;
+    width: 42px;
+    height: 42px;
+    font-size: 1.3rem;
+    font-weight: bold;
+    line-height: 1;
+    cursor: pointer;
+    flex-shrink: 0;
+}
+.db-arrow:active { transform: scale(0.92); }
+
+.db-draw {
+    position: relative;
+    display: flex;
+    align-items: center;
+    min-width: 110px;
+    min-height: 64px;
+    justify-content: center;
+}
+
+.db-side {
+    display: flex;
+    align-items: center;
+    gap: 2px;
+}
+
+.db-disc {
+    width: 10px;
+    background: linear-gradient(90deg, #3d566e, #2c3e50);
+    border-radius: 3px;
+    box-shadow: inset -2px 0 3px rgba(0,0,0,0.3);
+}
+
+.db-handle {
+    width: 44px;
+    height: 7px;
+    background: linear-gradient(#b8c2cc, #8f9aa5);
+    border-radius: 2px;
+}
+
+.db-weight-label {
+    position: absolute;
+    bottom: -22px;
+    left: 0;
+    right: 0;
+    text-align: center;
     font-size: 0.95rem;
     font-weight: bold;
-    cursor: pointer;
+    color: #4a76a8;
+    font-variant-numeric: tabular-nums;
 }
-.stepper-btn:active { background-color: #e8e8e8; }
 
-.stepper-label {
-    font-size: 0.78rem;
-    color: #999;
-    flex: 1;
-    text-align: center;
+/* Machine pin stack */
+.machine-visual {
+    display: flex;
+    justify-content: center;
+    background-color: #f4f7fa;
+    border-radius: 5px;
+    padding: 0.6rem;
+    margin-bottom: 0.5rem;
+}
+
+.machine-stack {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    width: 150px;
+}
+
+.stack-plate {
+    position: relative;
+    height: 15px;
+    background-color: #d5dde5;
+    border: none;
+    border-radius: 2px;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+}
+
+.stack-plate-num {
+    font-size: 0.62rem;
+    font-weight: bold;
+    color: #8a98a8;
+    line-height: 1;
+    pointer-events: none;
+}
+
+.stack-plate.selected {
+    background-color: #4a76a8;
+}
+
+.stack-plate.selected .stack-plate-num {
+    color: white;
+}
+
+.stack-plate.pinned::after {
+    content: '';
+    position: absolute;
+    right: -16px;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    background-color: #f1c40f;
+    border: 2px solid #d4ac0d;
+}
+
+/* Brief highlight when the picker fills inputs */
+.weight-input.just-filled {
+    background-color: #eafaf1;
+    transition: background-color 0.4s;
 }
 
 .picker-hint {

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -739,8 +739,8 @@ footer {
     font-size: 1rem;
 }
 
-/* ── Plate picker ───────────────────────────────────────────── */
-.plate-picker {
+/* ── Weight picker ──────────────────────────────────────────── */
+.weight-picker {
     background-color: white;
     border: 1px solid #e0e6ec;
     border-radius: 6px;
@@ -748,26 +748,192 @@ footer {
     margin-bottom: 1rem;
 }
 
-.plate-picker-header {
+.picker-header {
     display: flex;
-    align-items: baseline;
-    justify-content: space-between;
-    margin-bottom: 0.5rem;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.6rem;
 }
 
-.plate-picker-title {
+.picker-title {
     font-size: 0.8rem;
     font-weight: bold;
     text-transform: uppercase;
     letter-spacing: 0.04em;
     color: #888;
+    flex: 1;
 }
 
-.plate-total {
-    font-size: 1.2rem;
+.picker-total {
+    font-size: 1.15rem;
     font-weight: bold;
     color: #4a76a8;
     font-variant-numeric: tabular-nums;
+}
+
+.picker-settings-btn {
+    background: none;
+    border: none;
+    color: #aaa;
+    font-size: 1rem;
+    cursor: pointer;
+    padding: 0.1rem 0.3rem;
+    border-radius: 3px;
+    line-height: 1;
+}
+.picker-settings-btn:hover { color: #555; }
+
+/* Settings panel */
+.picker-settings-panel {
+    background-color: #f4f7fa;
+    border-radius: 5px;
+    padding: 0.6rem;
+    margin-bottom: 0.75rem;
+}
+
+.settings-row {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.35rem;
+    margin-bottom: 0.35rem;
+}
+.settings-row:last-child { margin-bottom: 0; }
+
+.settings-label {
+    font-size: 0.78rem;
+    font-weight: bold;
+    color: #888;
+    min-width: 60px;
+}
+
+.settings-opt-btn {
+    background-color: white;
+    border: 1px solid #cdd5de;
+    color: #555;
+    border-radius: 20px;
+    padding: 0.2rem 0.65rem;
+    font-size: 0.8rem;
+    cursor: pointer;
+}
+.settings-opt-btn.active {
+    background-color: #4a76a8;
+    border-color: #4a76a8;
+    color: white;
+}
+
+/* Action buttons row */
+.picker-actions {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.35rem;
+    margin-top: 0.5rem;
+}
+
+.action-label {
+    font-size: 0.75rem;
+    color: #999;
+    font-weight: bold;
+}
+
+.action-sep {
+    width: 1px;
+    height: 16px;
+    background-color: #ddd;
+    margin: 0 0.1rem;
+}
+
+.action-btn {
+    border-radius: 4px;
+    padding: 0.28rem 0.6rem;
+    font-size: 0.82rem;
+    font-weight: bold;
+    cursor: pointer;
+    border: 1px solid transparent;
+    white-space: nowrap;
+}
+.action-btn.ghost {
+    background-color: #f5f5f5;
+    border-color: #ddd;
+    color: #666;
+}
+.action-btn.blue {
+    background-color: #e8f0f8;
+    border-color: #c8d8e8;
+    color: #4a76a8;
+}
+.action-btn.blue.applied {
+    background-color: #27ae60;
+    border-color: #27ae60;
+    color: white;
+}
+.action-btn.muted {
+    background-color: transparent;
+    border-color: transparent;
+    color: #bbb;
+    margin-left: auto;
+    font-size: 1rem;
+}
+
+/* Dumbbell weight grid */
+.db-steps {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+    margin-bottom: 0.5rem;
+}
+
+.db-step-btn {
+    background-color: #f5f8fc;
+    border: 1px solid #d0dce8;
+    color: #4a76a8;
+    border-radius: 20px;
+    padding: 0.25rem 0.7rem;
+    font-size: 0.85rem;
+    font-weight: bold;
+    cursor: pointer;
+    white-space: nowrap;
+}
+.db-step-btn.selected {
+    background-color: #4a76a8;
+    border-color: #4a76a8;
+    color: white;
+}
+.db-step-btn:active { transform: scale(0.94); }
+
+/* Machine stepper */
+.machine-stepper {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.25rem;
+}
+
+.stepper-btn {
+    background-color: #f5f5f5;
+    border: 1px solid #ddd;
+    color: #333;
+    border-radius: 4px;
+    padding: 0.4rem 0.8rem;
+    font-size: 0.95rem;
+    font-weight: bold;
+    cursor: pointer;
+}
+.stepper-btn:active { background-color: #e8e8e8; }
+
+.stepper-label {
+    font-size: 0.78rem;
+    color: #999;
+    flex: 1;
+    text-align: center;
+}
+
+.picker-hint {
+    font-size: 0.78rem;
+    color: #aaa;
+    margin: 0;
+    text-align: center;
 }
 
 .barbell-visual {
@@ -846,43 +1012,6 @@ footer {
     transform: scale(0.92);
 }
 
-.plate-apply {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    gap: 0.4rem;
-}
-
-.plate-apply-label {
-    font-size: 0.8rem;
-    color: #888;
-    font-weight: bold;
-}
-
-.plate-apply-btn,
-.plate-clear-btn {
-    background-color: #e8f0f8;
-    border: 1px solid #c8d8e8;
-    color: #4a76a8;
-    border-radius: 4px;
-    padding: 0.35rem 0.7rem;
-    font-size: 0.85rem;
-    font-weight: bold;
-    cursor: pointer;
-}
-
-.plate-apply-btn.applied {
-    background-color: #27ae60;
-    border-color: #27ae60;
-    color: white;
-}
-
-.plate-clear-btn {
-    background-color: #f5f5f5;
-    border-color: #ddd;
-    color: #888;
-    margin-left: auto;
-}
 
 /* ── Bottom timer bar ───────────────────────────────────────── */
 .timer-bar {

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -739,6 +739,189 @@ footer {
     font-size: 1rem;
 }
 
+/* ── Workout launcher ───────────────────────────────────────── */
+.workout-launcher {
+    background-color: white;
+    border-radius: 8px;
+    padding: 1.25rem 1rem;
+    margin-bottom: 1.5rem;
+    text-align: center;
+    box-shadow: 0 2px 6px rgba(0,0,0,0.08);
+}
+
+.launcher-title {
+    font-size: 1.05rem;
+    font-weight: bold;
+    color: #333;
+    margin-bottom: 0.75rem;
+}
+
+.launcher-btn {
+    display: block;
+    width: 100%;
+    padding: 0.9rem;
+    font-size: 1.1rem;
+    border-radius: 6px;
+}
+
+.launcher-hint {
+    margin-top: 0.6rem;
+    font-size: 0.78rem;
+    color: #999;
+}
+
+/* ── Routine edit mode ──────────────────────────────────────── */
+.edit-routine-btn {
+    margin-left: auto;
+    background: none;
+    border: 1px solid #c8d8e8;
+    color: #4a76a8;
+    border-radius: 4px;
+    padding: 0.3rem 0.7rem;
+    font-size: 0.85rem;
+    font-weight: bold;
+    cursor: pointer;
+    align-self: center;
+    margin-bottom: 2px;
+}
+
+.edit-routine-btn.active {
+    background-color: #4a76a8;
+    color: white;
+}
+
+/* edit-only elements appear only while edit mode is on */
+.edit-only {
+    display: none;
+}
+
+.routine-container.edit-mode .edit-only {
+    display: block;
+}
+
+.remove-exercise-form {
+    margin-left: 0.5rem;
+}
+.routine-container.edit-mode .remove-exercise-form {
+    display: inline-block;
+}
+
+.remove-exercise-btn {
+    background-color: #fdecea;
+    border: 1px solid #f5b7b1;
+    color: #c0392b;
+    border-radius: 50%;
+    width: 30px;
+    height: 30px;
+    font-size: 1.1rem;
+    line-height: 1;
+    cursor: pointer;
+}
+
+.restore-form {
+    text-align: center;
+    margin-bottom: 1rem;
+}
+
+.restore-btn {
+    background: none;
+    border: 1px dashed #c8d8e8;
+    color: #4a76a8;
+    border-radius: 4px;
+    padding: 0.4rem 0.9rem;
+    font-size: 0.85rem;
+    cursor: pointer;
+}
+
+.add-exercise-wrap {
+    margin-top: 0.25rem;
+}
+
+.add-exercise-toggle {
+    width: 100%;
+    background: none;
+    border: 1px dashed #b8c8d8;
+    color: #4a76a8;
+    border-radius: 5px;
+    padding: 0.6rem;
+    font-size: 0.9rem;
+    font-weight: bold;
+    cursor: pointer;
+}
+
+.add-exercise-box {
+    background-color: white;
+    border: 1px solid #e0e6ec;
+    border-radius: 5px;
+    padding: 1rem;
+    margin-top: 0.5rem;
+}
+
+.add-ex-row {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    margin-bottom: 1rem;
+    font-size: 0.9rem;
+    color: #666;
+}
+
+.add-ex-sets { width: 64px; }
+.add-ex-reps { width: 90px; }
+
+.add-ex-row input {
+    padding: 0.5rem;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    font-size: 1rem;
+}
+
+/* ── Equipment icons & badges ───────────────────────────────── */
+.eq-icon {
+    display: inline-flex;
+    align-items: center;
+    color: #4a76a8;
+}
+
+.eq-icon svg { display: block; }
+
+.picker-title svg,
+.settings-opt-btn svg {
+    vertical-align: -2px;
+}
+
+.custom-badge {
+    background-color: #fef5e7;
+    color: #b9770e;
+    font-size: 0.72rem;
+    padding: 0.1rem 0.4rem;
+    border-radius: 3px;
+    font-weight: bold;
+}
+
+/* ── Set add/remove controls ────────────────────────────────── */
+.set-controls {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.4rem;
+    margin: 0.25rem 0 0.5rem;
+}
+
+.set-ctrl-btn {
+    background-color: #f5f5f5;
+    border: 1px solid #ddd;
+    color: #555;
+    border-radius: 4px;
+    padding: 0.3rem 0.8rem;
+    font-size: 0.85rem;
+    font-weight: bold;
+    cursor: pointer;
+}
+
+.set-ctrl-btn:active {
+    background-color: #e8e8e8;
+}
+
 /* ── Weight picker ──────────────────────────────────────────── */
 .weight-picker {
     background-color: white;

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -208,6 +208,145 @@ document.addEventListener('DOMContentLoaded', function () {
         if (btn) btn.textContent = '▶';
     };
 
+    // ── Plate picker (barbell exercises) ───────────────────────────
+    const PLATE_DENOMS = {
+        lbs: [45, 35, 25, 10, 5, 2.5],
+        kg: [20, 15, 10, 5, 2.5, 1.25],
+    };
+    const BAR_WEIGHT = { lbs: 45, kg: 20 };
+    // Roughly the IPF colour convention, applied by size rank in both units
+    const PLATE_COLORS = ['#c0392b', '#2962a8', '#f1c40f', '#27ae60', '#7f8c8d', '#bdc3c7'];
+
+    function initPlatePickers() {
+        document.querySelectorAll('.plate-picker').forEach(function (picker) {
+            picker._plates = []; // weights loaded per side, in tap order
+            renderPlateButtons(picker);
+            renderBarbell(picker);
+        });
+    }
+
+    function resetPlatePickers() {
+        document.querySelectorAll('.plate-picker').forEach(function (picker) {
+            picker._plates = [];
+            renderPlateButtons(picker);
+            renderBarbell(picker);
+        });
+    }
+
+    function renderPlateButtons(picker) {
+        const container = picker.querySelector('.plate-buttons');
+        if (!container) return;
+        container.innerHTML = '';
+        PLATE_DENOMS[currentUnit].forEach(function (w, rank) {
+            const btn = document.createElement('button');
+            btn.type = 'button';
+            btn.className = 'plate-add-btn';
+            btn.dataset.weight = w;
+            btn.textContent = formatWeight(w);
+            btn.style.borderColor = PLATE_COLORS[rank];
+            container.appendChild(btn);
+        });
+    }
+
+    function renderBarbell(picker) {
+        const visual = picker.querySelector('.barbell-visual');
+        if (!visual) return;
+        visual.innerHTML = '';
+
+        const plates = picker._plates;
+        const denoms = PLATE_DENOMS[currentUnit];
+        const maxW = denoms[0];
+        // Heaviest plates sit closest to the centre of the bar
+        const sorted = plates
+            .map(function (w, i) { return { w: w, i: i }; })
+            .sort(function (a, b) { return b.w - a.w; });
+
+        function makePlate(entry) {
+            const el = document.createElement('button');
+            el.type = 'button';
+            el.className = 'bv-plate';
+            el.dataset.idx = entry.i;
+            el.title = 'Remove ' + formatWeight(entry.w) + ' ' + currentUnit + ' pair';
+            const ratio = entry.w / maxW;
+            el.style.height = Math.round(26 + 44 * ratio) + 'px';
+            el.style.width = Math.max(7, Math.round(14 * ratio)) + 'px';
+            el.style.backgroundColor = PLATE_COLORS[denoms.indexOf(entry.w)] || '#7f8c8d';
+            return el;
+        }
+
+        const left = document.createElement('div');
+        left.className = 'bv-side bv-left';
+        const right = document.createElement('div');
+        right.className = 'bv-side bv-right';
+        // Mirror: outermost (lightest) plate first on the left side
+        sorted.slice().reverse().forEach(function (e) { left.appendChild(makePlate(e)); });
+        sorted.forEach(function (e) { right.appendChild(makePlate(e)); });
+
+        const bar = document.createElement('div');
+        bar.className = 'bv-bar';
+
+        visual.appendChild(left);
+        visual.appendChild(bar);
+        visual.appendChild(right);
+
+        if (plates.length === 0) {
+            const hint = document.createElement('div');
+            hint.className = 'bv-hint';
+            hint.textContent = 'Tap a plate below to load the bar — tap a loaded plate to remove it';
+            visual.appendChild(hint);
+        }
+
+        const totalEl = picker.querySelector('.plate-total-value');
+        if (totalEl) totalEl.textContent = formatWeight(plateTotal(picker));
+    }
+
+    function plateTotal(picker) {
+        const perSide = picker._plates.reduce(function (sum, w) { return sum + w; }, 0);
+        return BAR_WEIGHT[currentUnit] + 2 * perSide;
+    }
+
+    function formatWeight(w) {
+        return (Math.round(w * 100) / 100).toString();
+    }
+
+    document.addEventListener('click', function (e) {
+        const picker = e.target.closest('.plate-picker');
+        if (!picker) return;
+
+        const addBtn = e.target.closest('.plate-add-btn');
+        if (addBtn) {
+            picker._plates.push(parseFloat(addBtn.dataset.weight));
+            renderBarbell(picker);
+            return;
+        }
+
+        const plateEl = e.target.closest('.bv-plate');
+        if (plateEl) {
+            picker._plates.splice(parseInt(plateEl.dataset.idx, 10), 1);
+            renderBarbell(picker);
+            return;
+        }
+
+        const applyBtn = e.target.closest('.plate-apply-btn');
+        if (applyBtn) {
+            const panel = picker.closest('.exercise-panel');
+            const input = panel && panel.querySelector('input[name="weight_set_' + applyBtn.dataset.set + '"]');
+            if (input) {
+                input.value = plateTotal(picker);
+                applyBtn.classList.add('applied');
+                setTimeout(function () { applyBtn.classList.remove('applied'); }, 600);
+            }
+            return;
+        }
+
+        if (e.target.closest('.plate-clear-btn')) {
+            picker._plates = [];
+            renderBarbell(picker);
+        }
+    });
+
+    initPlatePickers();
+
     // ── Unit conversion ────────────────────────────────────────────
     function convertWeight(value, from, to) {
         if (from === to) return value;
@@ -227,6 +366,7 @@ document.addEventListener('DOMContentLoaded', function () {
         currentUnit = unit;
         localStorage.setItem('weightUnit', currentUnit);
         applyUnitUI(document);
+        resetPlatePickers(); // plate denominations are physical — swap sets, don't convert
     };
 
     function applyUnitUI(root) {

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -1,17 +1,31 @@
 document.addEventListener('DOMContentLoaded', function () {
     'use strict';
 
+    // ── Shared helpers ─────────────────────────────────────────────
+    function mkEl(tag, cls) {
+        const e = document.createElement(tag);
+        if (cls) e.className = cls;
+        return e;
+    }
+    function fmtW(w) { return (Math.round(w * 100) / 100).toString(); }
+    function pad2(n) { return String(n).padStart(2, '0'); }
+
     // ── Constants ──────────────────────────────────────────────────
     const LBS_PER_KG = 2.20462;
+    const PLATE_LBS  = [45, 35, 25, 10, 5, 2.5];
+    const PLATE_KG   = [20, 15, 10, 5, 2.5, 1.25];
+    const BAR_LBS    = [45, 35, 25];   // standard / women's / technique
+    const BAR_KG     = [20, 15, 10];
+    const DB_LBS = [5, 7.5, 10, 12.5, 15, 17.5, 20, 22.5, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80];
+    const DB_KG  = [4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 35, 37.5, 40];
+    const PLATE_COLORS = ['#c0392b', '#2962a8', '#f1c40f', '#27ae60', '#7f8c8d', '#bdc3c7'];
 
     // ── Unit state ─────────────────────────────────────────────────
     let currentUnit = localStorage.getItem('weightUnit') || 'lbs';
 
-    // ── Timer state ────────────────────────────────────────────────
-    let timerSeconds = 0;
-    let timerInterval = null;
-    let timerRunning = false;
-    let timerRestPeriod = 90;
+    function curPlates()  { return currentUnit === 'kg' ? PLATE_KG  : PLATE_LBS; }
+    function curBarOpts() { return currentUnit === 'kg' ? BAR_KG    : BAR_LBS;   }
+    function curDbSteps() { return currentUnit === 'kg' ? DB_KG     : DB_LBS;    }
 
     // ── Card accordion ─────────────────────────────────────────────
     let openCardId = null;
@@ -19,11 +33,8 @@ document.addEventListener('DOMContentLoaded', function () {
     document.addEventListener('click', function (e) {
         const header = e.target.closest('.exercise-card-header');
         if (!header) return;
-        if (header.dataset.card) {
-            toggleCard(header.dataset.card);
-        } else if (header.dataset.href) {
-            window.location.href = header.dataset.href;
-        }
+        if (header.dataset.card) toggleCard(header.dataset.card);
+        else if (header.dataset.href) window.location.href = header.dataset.href;
     });
 
     document.addEventListener('keydown', function (e) {
@@ -31,26 +42,15 @@ document.addEventListener('DOMContentLoaded', function () {
         const header = e.target.closest('.exercise-card-header');
         if (!header) return;
         e.preventDefault();
-        if (header.dataset.card) {
-            toggleCard(header.dataset.card);
-        } else if (header.dataset.href) {
-            window.location.href = header.dataset.href;
-        }
+        if (header.dataset.card) toggleCard(header.dataset.card);
+        else if (header.dataset.href) window.location.href = header.dataset.href;
     });
 
     function toggleCard(cardId) {
         const panel = document.getElementById('panel-' + cardId);
         if (!panel) return;
-
-        if (openCardId && openCardId !== cardId) {
-            collapseCard(openCardId);
-        }
-
-        if (!panel.hidden) {
-            collapseCard(cardId);
-        } else {
-            expandCard(cardId);
-        }
+        if (openCardId && openCardId !== cardId) collapseCard(openCardId);
+        panel.hidden ? expandCard(cardId) : collapseCard(cardId);
     }
 
     function expandCard(cardId) {
@@ -69,11 +69,11 @@ document.addEventListener('DOMContentLoaded', function () {
         setExpandIcon(cardId, false);
     }
 
-    function setExpandIcon(cardId, isOpen) {
-        const header = document.querySelector('.exercise-card-header[data-card="' + cardId + '"]');
-        if (!header) return;
-        const icon = header.querySelector('.expand-icon');
-        if (icon) icon.classList.toggle('open', isOpen);
+    function setExpandIcon(cardId, open) {
+        const h = document.querySelector('.exercise-card-header[data-card="' + cardId + '"]');
+        if (!h) return;
+        const icon = h.querySelector('.expand-icon');
+        if (icon) icon.classList.toggle('open', open);
     }
 
     // ── AJAX form submit ───────────────────────────────────────────
@@ -81,10 +81,8 @@ document.addEventListener('DOMContentLoaded', function () {
         const form = e.target;
         if (!form.classList.contains('exercise-log-form')) return;
         e.preventDefault();
-
         const btn = form.querySelector('[type="submit"]');
         if (btn) btn.disabled = true;
-
         const errDiv = form.querySelector('.form-error');
         if (errDiv) errDiv.textContent = '';
 
@@ -97,317 +95,468 @@ document.addEventListener('DOMContentLoaded', function () {
             .then(function (data) {
                 if (btn) btn.disabled = false;
                 if (data.status === 'ok') {
-                    const cardId = form.dataset.cardId;
-                    markCardDone(cardId, data.sets_completed);
-                    collapseCard(cardId);
+                    markCardDone(form.dataset.cardId, data.sets_completed);
+                    collapseCard(form.dataset.cardId);
                     startTimer(data.rest_period, data.exercise_name);
-                    if (data.advanced && data.new_progression) {
-                        showAdvancementBanner(data.new_progression);
-                    }
+                    if (data.advanced && data.new_progression) showAdvancementBanner(data.new_progression);
                 } else {
                     if (errDiv) errDiv.textContent = data.message || 'Error logging exercise.';
                 }
             })
-            .catch(function () {
-                if (btn) btn.disabled = false;
-                form.submit();
-            });
+            .catch(function () { if (btn) btn.disabled = false; form.submit(); });
     });
 
-    function markCardDone(cardId, setsCompleted) {
-        const header = document.querySelector('.exercise-card-header[data-card="' + cardId + '"]');
-        if (!header) return;
-        let badge = header.querySelector('.logged-badge');
-        if (!badge) {
-            badge = document.createElement('span');
-            badge.className = 'logged-badge';
-            header.appendChild(badge);
-        }
-        badge.textContent = '✓ ' + setsCompleted + (setsCompleted === 1 ? ' set' : ' sets');
+    function markCardDone(cardId, n) {
+        const h = document.querySelector('.exercise-card-header[data-card="' + cardId + '"]');
+        if (!h) return;
+        let badge = h.querySelector('.logged-badge');
+        if (!badge) { badge = mkEl('span', 'logged-badge'); h.appendChild(badge); }
+        badge.textContent = '✓ ' + n + (n === 1 ? ' set' : ' sets');
     }
 
-    function showAdvancementBanner(newProgression) {
-        const banner = document.createElement('div');
-        banner.className = 'advancement-banner';
-        banner.textContent = 'Advanced to: ' + newProgression;
-        const main = document.querySelector('main');
-        if (main) main.insertAdjacentElement('afterbegin', banner);
-        setTimeout(function () { banner.remove(); }, 5000);
+    function showAdvancementBanner(name) {
+        const b = mkEl('div', 'advancement-banner');
+        b.textContent = 'Advanced to: ' + name;
+        const m = document.querySelector('main');
+        if (m) m.insertAdjacentElement('afterbegin', b);
+        setTimeout(function () { b.remove(); }, 5000);
     }
 
     // ── Timer ──────────────────────────────────────────────────────
+    let timerSeconds = 0;
+    let timerInterval = null;
+    let timerRunning = false;
+    let timerRestPeriod = 90;
+
     function startTimer(restPeriod, exerciseName) {
         timerRestPeriod = restPeriod || 90;
         timerSeconds = timerRestPeriod;
         clearInterval(timerInterval);
         timerRunning = true;
-
         const bar = document.getElementById('timer-bar');
         if (bar) bar.hidden = false;
         document.body.classList.add('timer-visible');
-
         const label = document.getElementById('timer-exercise');
         if (label) label.textContent = exerciseName || '';
-
-        const toggleBtn = document.getElementById('timer-bar-toggle');
-        if (toggleBtn) toggleBtn.textContent = '⏸';
-
+        const btn = document.getElementById('timer-bar-toggle');
+        if (btn) btn.textContent = '⏸';
         updateTimerDisplay();
         timerInterval = setInterval(timerTick, 1000);
     }
 
     function timerTick() {
-        if (timerSeconds > 0) {
-            timerSeconds--;
-            updateTimerDisplay();
-        } else {
-            clearInterval(timerInterval);
-            timerRunning = false;
-            const disp = document.getElementById('timer-bar-display');
-            if (disp) disp.textContent = 'REST ✓';
-            const btn = document.getElementById('timer-bar-toggle');
-            if (btn) btn.textContent = '▶';
-            if (navigator.vibrate) navigator.vibrate([200, 100, 200]);
-        }
+        if (timerSeconds > 0) { timerSeconds--; updateTimerDisplay(); return; }
+        clearInterval(timerInterval);
+        timerRunning = false;
+        const d = document.getElementById('timer-bar-display');
+        if (d) d.textContent = 'REST ✓';
+        const b = document.getElementById('timer-bar-toggle');
+        if (b) b.textContent = '▶';
+        if (navigator.vibrate) navigator.vibrate([200, 100, 200]);
     }
 
     function updateTimerDisplay() {
-        const m = Math.floor(timerSeconds / 60);
-        const s = timerSeconds % 60;
-        const disp = document.getElementById('timer-bar-display');
-        if (disp) disp.textContent = pad2(m) + ':' + pad2(s);
+        const d = document.getElementById('timer-bar-display');
+        if (d) d.textContent = pad2(Math.floor(timerSeconds / 60)) + ':' + pad2(timerSeconds % 60);
     }
-
-    function pad2(n) { return String(n).padStart(2, '0'); }
 
     window.timerToggle = function () {
         if (timerRunning) {
-            clearInterval(timerInterval);
-            timerRunning = false;
-            const btn = document.getElementById('timer-bar-toggle');
-            if (btn) btn.textContent = '▶';
+            clearInterval(timerInterval); timerRunning = false;
+            const b = document.getElementById('timer-bar-toggle'); if (b) b.textContent = '▶';
         } else {
             timerRunning = true;
-            const btn = document.getElementById('timer-bar-toggle');
-            if (btn) btn.textContent = '⏸';
+            const b = document.getElementById('timer-bar-toggle'); if (b) b.textContent = '⏸';
             timerInterval = setInterval(timerTick, 1000);
         }
     };
-
-    window.timerAdjust = function (delta) {
-        timerSeconds = Math.max(0, timerSeconds + delta);
+    window.timerAdjust = function (d) { timerSeconds = Math.max(0, timerSeconds + d); updateTimerDisplay(); };
+    window.timerReset  = function () {
+        clearInterval(timerInterval); timerRunning = false; timerSeconds = timerRestPeriod;
         updateTimerDisplay();
+        const b = document.getElementById('timer-bar-toggle'); if (b) b.textContent = '▶';
     };
 
-    window.timerReset = function () {
-        clearInterval(timerInterval);
-        timerRunning = false;
-        timerSeconds = timerRestPeriod;
-        updateTimerDisplay();
-        const btn = document.getElementById('timer-bar-toggle');
-        if (btn) btn.textContent = '▶';
-    };
-
-    // ── Plate picker (barbell exercises) ───────────────────────────
-    const PLATE_DENOMS = {
-        lbs: [45, 35, 25, 10, 5, 2.5],
-        kg: [20, 15, 10, 5, 2.5, 1.25],
-    };
-    const BAR_WEIGHT = { lbs: 45, kg: 20 };
-    // Roughly the IPF colour convention, applied by size rank in both units
-    const PLATE_COLORS = ['#c0392b', '#2962a8', '#f1c40f', '#27ae60', '#7f8c8d', '#bdc3c7'];
-
-    function initPlatePickers() {
-        document.querySelectorAll('.plate-picker').forEach(function (picker) {
-            picker._plates = []; // weights loaded per side, in tap order
-            renderPlateButtons(picker);
-            renderBarbell(picker);
-        });
+    // ── Weight picker ──────────────────────────────────────────────
+    function getExPref(name) {
+        try { return JSON.parse(localStorage.getItem('gymPref_' + name) || '{}'); }
+        catch (e) { return {}; }
+    }
+    function setExPref(name, patch) {
+        localStorage.setItem('gymPref_' + name, JSON.stringify(Object.assign({}, getExPref(name), patch)));
+    }
+    function pickerEquipment(p) {
+        return getExPref(p.dataset.exercise).equipment || p.dataset.defaultEquipment || 'machine';
+    }
+    function pickerBarWeight(p) {
+        const pref = getExPref(p.dataset.exercise);
+        return (currentUnit === 'kg' ? pref.barWeightKg : pref.barWeightLbs) || curBarOpts()[0];
+    }
+    function getSetInputs(p) {
+        const panel = p.closest('.exercise-panel');
+        return panel ? Array.from(panel.querySelectorAll('input[name^="weight_set_"]')) : [];
     }
 
-    function resetPlatePickers() {
-        document.querySelectorAll('.plate-picker').forEach(function (picker) {
-            picker._plates = [];
-            renderPlateButtons(picker);
-            renderBarbell(picker);
+    function buildPicker(p) {
+        const eq = pickerEquipment(p);
+        if (p._lastEq && p._lastEq !== eq) p._plates = [];
+        p._lastEq = eq;
+        p._plates = p._plates || [];
+        p.innerHTML = '';
+
+        // Header row
+        const hdr = mkEl('div', 'picker-header');
+        const title = mkEl('span', 'picker-title');
+        title.textContent = eq === 'barbell' ? 'Plate calculator'
+                          : eq === 'dumbbell' ? 'Dumbbell weight'
+                          : 'Quick fill';
+        hdr.appendChild(title);
+        if (eq === 'barbell') {
+            const tot = mkEl('span', 'picker-total');
+            tot.innerHTML = '<span class="picker-total-value"></span> <span class="unit-display picker-unit"></span>';
+            hdr.appendChild(tot);
+        }
+        const settingsBtn = mkEl('button', 'picker-settings-btn');
+        settingsBtn.type = 'button';
+        settingsBtn.textContent = '⚙';
+        settingsBtn.title = 'Equipment settings';
+        hdr.appendChild(settingsBtn);
+        p.appendChild(hdr);
+
+        // Settings panel (hidden until ⚙ tapped)
+        const sp = mkEl('div', 'picker-settings-panel');
+        sp.hidden = true;
+        const eqRow = mkEl('div', 'settings-row');
+        const eqLabel = mkEl('span', 'settings-label');
+        eqLabel.textContent = 'Equipment:';
+        eqRow.appendChild(eqLabel);
+        ['barbell', 'dumbbell', 'machine'].forEach(function (t) {
+            const b = mkEl('button', 'settings-opt-btn' + (t === eq ? ' active' : ''));
+            b.type = 'button';
+            b.dataset.setEquipment = t;
+            b.textContent = t.charAt(0).toUpperCase() + t.slice(1);
+            eqRow.appendChild(b);
         });
+        sp.appendChild(eqRow);
+        if (eq === 'barbell') {
+            const bwRow = mkEl('div', 'settings-row');
+            const bwLabel = mkEl('span', 'settings-label');
+            bwLabel.textContent = 'Bar:';
+            bwRow.appendChild(bwLabel);
+            const curBW = pickerBarWeight(p);
+            curBarOpts().forEach(function (w) {
+                const b = mkEl('button', 'settings-opt-btn' + (w === curBW ? ' active' : ''));
+                b.type = 'button';
+                b.dataset.setBarWeight = w;
+                b.textContent = fmtW(w) + ' ' + currentUnit;
+                bwRow.appendChild(b);
+            });
+            sp.appendChild(bwRow);
+        }
+        p.appendChild(sp);
+
+        // Main content
+        if (eq === 'barbell')      buildBarbellContent(p);
+        else if (eq === 'dumbbell') buildDumbbellContent(p);
+        else                        buildMachineContent(p);
     }
 
-    function renderPlateButtons(picker) {
-        const container = picker.querySelector('.plate-buttons');
-        if (!container) return;
-        container.innerHTML = '';
-        PLATE_DENOMS[currentUnit].forEach(function (w, rank) {
-            const btn = document.createElement('button');
-            btn.type = 'button';
-            btn.className = 'plate-add-btn';
-            btn.dataset.weight = w;
-            btn.textContent = formatWeight(w);
-            btn.style.borderColor = PLATE_COLORS[rank];
-            container.appendChild(btn);
+    function buildBarbellContent(p) {
+        p.appendChild(mkEl('div', 'barbell-visual'));
+
+        const btns = mkEl('div', 'plate-buttons');
+        curPlates().forEach(function (w, i) {
+            const b = mkEl('button', 'plate-add-btn');
+            b.type = 'button';
+            b.dataset.addPlate = w;
+            b.textContent = fmtW(w);
+            b.style.borderColor = PLATE_COLORS[i];
+            btns.appendChild(b);
         });
+        p.appendChild(btns);
+
+        const acts = mkEl('div', 'picker-actions');
+        const setInputs = getSetInputs(p);
+        if (setInputs.length) {
+            const fromLabel = mkEl('span', 'action-label');
+            fromLabel.textContent = 'Load from:';
+            acts.appendChild(fromLabel);
+            setInputs.forEach(function (_, i) {
+                const b = mkEl('button', 'action-btn ghost');
+                b.type = 'button';
+                b.dataset.loadFrom = i + 1;
+                b.textContent = 'Set ' + (i + 1);
+                acts.appendChild(b);
+            });
+            acts.appendChild(mkEl('span', 'action-sep'));
+            const fillLabel = mkEl('span', 'action-label');
+            fillLabel.textContent = 'Fill:';
+            acts.appendChild(fillLabel);
+            setInputs.forEach(function (_, i) {
+                const b = mkEl('button', 'action-btn blue');
+                b.type = 'button';
+                b.dataset.fillSet = i + 1;
+                b.textContent = 'Set ' + (i + 1);
+                acts.appendChild(b);
+            });
+        }
+        const clrBtn = mkEl('button', 'action-btn muted');
+        clrBtn.type = 'button';
+        clrBtn.dataset.clearPlates = '1';
+        clrBtn.textContent = '↺';
+        acts.appendChild(clrBtn);
+        p.appendChild(acts);
+
+        drawBarbell(p);
     }
 
-    function renderBarbell(picker) {
-        const visual = picker.querySelector('.barbell-visual');
-        if (!visual) return;
-        visual.innerHTML = '';
+    function buildDumbbellContent(p) {
+        const steps = mkEl('div', 'db-steps');
+        curDbSteps().forEach(function (w) {
+            const b = mkEl('button', 'db-step-btn');
+            b.type = 'button';
+            b.dataset.dbWeight = w;
+            b.textContent = fmtW(w);
+            steps.appendChild(b);
+        });
+        p.appendChild(steps);
+        const hint = mkEl('p', 'picker-hint');
+        hint.textContent = 'Tap a weight to fill all sets';
+        p.appendChild(hint);
+    }
 
-        const plates = picker._plates;
-        const denoms = PLATE_DENOMS[currentUnit];
-        const maxW = denoms[0];
-        // Heaviest plates sit closest to the centre of the bar
-        const sorted = plates
+    function buildMachineContent(p) {
+        const step = currentUnit === 'kg' ? 2.5 : 5;
+        const row = mkEl('div', 'machine-stepper');
+        const minus = mkEl('button', 'stepper-btn');
+        minus.type = 'button';
+        minus.dataset.machineStep = -step;
+        minus.textContent = '−' + fmtW(step);
+        const lbl = mkEl('span', 'stepper-label');
+        lbl.textContent = 'Adjust all sets';
+        const plus = mkEl('button', 'stepper-btn');
+        plus.type = 'button';
+        plus.dataset.machineStep = step;
+        plus.textContent = '+' + fmtW(step);
+        row.appendChild(minus);
+        row.appendChild(lbl);
+        row.appendChild(plus);
+        p.appendChild(row);
+    }
+
+    function drawBarbell(p) {
+        const v = p.querySelector('.barbell-visual');
+        if (!v) return;
+        v.innerHTML = '';
+
+        const plates  = p._plates || [];
+        const barW    = pickerBarWeight(p);
+        const denoms  = curPlates();
+        const maxW    = denoms[0];
+        const sorted  = plates
             .map(function (w, i) { return { w: w, i: i }; })
             .sort(function (a, b) { return b.w - a.w; });
 
-        function makePlate(entry) {
-            const el = document.createElement('button');
-            el.type = 'button';
-            el.className = 'bv-plate';
-            el.dataset.idx = entry.i;
-            el.title = 'Remove ' + formatWeight(entry.w) + ' ' + currentUnit + ' pair';
+        function mkPlate(entry) {
+            const btn = mkEl('button', 'bv-plate');
+            btn.type = 'button';
+            btn.dataset.removePlate = entry.i;
+            btn.title = 'Remove ' + fmtW(entry.w) + ' ' + currentUnit;
             const ratio = entry.w / maxW;
-            el.style.height = Math.round(26 + 44 * ratio) + 'px';
-            el.style.width = Math.max(7, Math.round(14 * ratio)) + 'px';
-            el.style.backgroundColor = PLATE_COLORS[denoms.indexOf(entry.w)] || '#7f8c8d';
-            return el;
+            btn.style.height = Math.round(26 + 44 * ratio) + 'px';
+            btn.style.width  = Math.max(7, Math.round(14 * ratio)) + 'px';
+            const ci = denoms.indexOf(entry.w);
+            btn.style.backgroundColor = PLATE_COLORS[ci >= 0 ? ci : denoms.length - 1];
+            return btn;
         }
 
-        const left = document.createElement('div');
-        left.className = 'bv-side bv-left';
-        const right = document.createElement('div');
-        right.className = 'bv-side bv-right';
-        // Mirror: outermost (lightest) plate first on the left side
-        sorted.slice().reverse().forEach(function (e) { left.appendChild(makePlate(e)); });
-        sorted.forEach(function (e) { right.appendChild(makePlate(e)); });
+        const L = mkEl('div', 'bv-side bv-left');
+        const R = mkEl('div', 'bv-side bv-right');
+        sorted.slice().reverse().forEach(function (e) { L.appendChild(mkPlate(e)); });
+        sorted.forEach(function (e) { R.appendChild(mkPlate(e)); });
 
-        const bar = document.createElement('div');
-        bar.className = 'bv-bar';
+        v.appendChild(L);
+        v.appendChild(mkEl('div', 'bv-bar'));
+        v.appendChild(R);
 
-        visual.appendChild(left);
-        visual.appendChild(bar);
-        visual.appendChild(right);
-
-        if (plates.length === 0) {
-            const hint = document.createElement('div');
-            hint.className = 'bv-hint';
-            hint.textContent = 'Tap a plate below to load the bar — tap a loaded plate to remove it';
-            visual.appendChild(hint);
+        if (!plates.length) {
+            const hint = mkEl('div', 'bv-hint');
+            hint.textContent = 'Tap a plate to load it';
+            v.appendChild(hint);
         }
 
-        const totalEl = picker.querySelector('.plate-total-value');
-        if (totalEl) totalEl.textContent = formatWeight(plateTotal(picker));
+        const total = barW + 2 * plates.reduce(function (s, w) { return s + w; }, 0);
+        const tv = p.querySelector('.picker-total-value');
+        if (tv) tv.textContent = fmtW(total);
+        p.querySelectorAll('.picker-unit').forEach(function (el) { el.textContent = currentUnit; });
+        return total;
     }
 
-    function plateTotal(picker) {
-        const perSide = picker._plates.reduce(function (sum, w) { return sum + w; }, 0);
-        return BAR_WEIGHT[currentUnit] + 2 * perSide;
+    // Greedy reverse calc: find closest plate arrangement ≤ target weight
+    function reverseCalc(p, targetWeight) {
+        const barW = pickerBarWeight(p);
+        let perSide = (targetWeight - barW) / 2;
+        const plates = [];
+        if (perSide > 0) {
+            curPlates().forEach(function (d) {
+                while (perSide >= d - 0.001) { plates.push(d); perSide -= d; }
+            });
+        }
+        p._plates = plates;
+        drawBarbell(p);
     }
 
-    function formatWeight(w) {
-        return (Math.round(w * 100) / 100).toString();
-    }
-
+    // Picker delegated click handler
     document.addEventListener('click', function (e) {
-        const picker = e.target.closest('.plate-picker');
-        if (!picker) return;
+        const p = e.target.closest('.weight-picker');
+        if (!p) return;
 
-        const addBtn = e.target.closest('.plate-add-btn');
-        if (addBtn) {
-            picker._plates.push(parseFloat(addBtn.dataset.weight));
-            renderBarbell(picker);
+        // ⚙ toggle settings
+        if (e.target.closest('.picker-settings-btn')) {
+            const sp = p.querySelector('.picker-settings-panel');
+            if (sp) sp.hidden = !sp.hidden;
             return;
         }
-
-        const plateEl = e.target.closest('.bv-plate');
-        if (plateEl) {
-            picker._plates.splice(parseInt(plateEl.dataset.idx, 10), 1);
-            renderBarbell(picker);
+        // Change equipment type
+        const eqEl = e.target.closest('[data-set-equipment]');
+        if (eqEl) {
+            setExPref(p.dataset.exercise, { equipment: eqEl.dataset.setEquipment });
+            buildPicker(p);
             return;
         }
-
-        const applyBtn = e.target.closest('.plate-apply-btn');
-        if (applyBtn) {
-            const panel = picker.closest('.exercise-panel');
-            const input = panel && panel.querySelector('input[name="weight_set_' + applyBtn.dataset.set + '"]');
-            if (input) {
-                input.value = plateTotal(picker);
-                applyBtn.classList.add('applied');
-                setTimeout(function () { applyBtn.classList.remove('applied'); }, 600);
+        // Change bar weight
+        const bwEl = e.target.closest('[data-set-bar-weight]');
+        if (bwEl) {
+            const key = currentUnit === 'kg' ? 'barWeightKg' : 'barWeightLbs';
+            const patch = {};
+            patch[key] = parseFloat(bwEl.dataset.setBarWeight);
+            setExPref(p.dataset.exercise, patch);
+            buildPicker(p);
+            return;
+        }
+        // Add plate
+        const addEl = e.target.closest('[data-add-plate]');
+        if (addEl) {
+            (p._plates = p._plates || []).push(parseFloat(addEl.dataset.addPlate));
+            drawBarbell(p);
+            return;
+        }
+        // Remove plate (tap on barbell visual)
+        const remEl = e.target.closest('[data-remove-plate]');
+        if (remEl) {
+            if (p._plates) p._plates.splice(parseInt(remEl.dataset.removePlate, 10), 1);
+            drawBarbell(p);
+            return;
+        }
+        // Clear all plates
+        if (e.target.closest('[data-clear-plates]')) {
+            p._plates = [];
+            drawBarbell(p);
+            return;
+        }
+        // Load from set input → reverse-calc plates
+        const fromEl = e.target.closest('[data-load-from]');
+        if (fromEl) {
+            const inp = getSetInputs(p)[parseInt(fromEl.dataset.loadFrom, 10) - 1];
+            if (inp) {
+                const v = parseFloat(inp.value);
+                if (!isNaN(v) && v > 0) reverseCalc(p, v);
             }
             return;
         }
-
-        if (e.target.closest('.plate-clear-btn')) {
-            picker._plates = [];
-            renderBarbell(picker);
+        // Fill set input ← barbell total
+        const fillEl = e.target.closest('[data-fill-set]');
+        if (fillEl) {
+            const total = drawBarbell(p);
+            const inp = getSetInputs(p)[parseInt(fillEl.dataset.fillSet, 10) - 1];
+            if (inp && total != null) {
+                inp.value = fmtW(total);
+                fillEl.classList.add('applied');
+                setTimeout(function () { fillEl.classList.remove('applied'); }, 600);
+            }
+            return;
+        }
+        // Machine stepper
+        const stepEl = e.target.closest('[data-machine-step]');
+        if (stepEl) {
+            const delta = parseFloat(stepEl.dataset.machineStep);
+            getSetInputs(p).forEach(function (inp) {
+                inp.value = fmtW(Math.max(0, (parseFloat(inp.value) || 0) + delta));
+            });
+            return;
+        }
+        // Dumbbell weight select
+        const dbEl = e.target.closest('[data-db-weight]');
+        if (dbEl) {
+            p.querySelectorAll('[data-db-weight]').forEach(function (b) { b.classList.remove('selected'); });
+            dbEl.classList.add('selected');
+            const w = parseFloat(dbEl.dataset.dbWeight);
+            getSetInputs(p).forEach(function (inp) { inp.value = fmtW(w); });
         }
     });
 
-    initPlatePickers();
+    function initPickers() {
+        document.querySelectorAll('.weight-picker').forEach(function (p) {
+            p._plates = [];
+            buildPicker(p);
+        });
+    }
+    function refreshPickers() {
+        document.querySelectorAll('.weight-picker').forEach(function (p) {
+            p._plates = [];
+            buildPicker(p);
+        });
+    }
+
+    initPickers();
 
     // ── Unit conversion ────────────────────────────────────────────
     function convertWeight(value, from, to) {
         if (from === to) return value;
         return from === 'lbs' ? value / LBS_PER_KG : value * LBS_PER_KG;
     }
-
     function roundWeight(v) { return Math.round(v * 2) / 2; }
 
     window.setUnit = function (unit) {
         if (unit === currentUnit) return;
         document.querySelectorAll('.weight-input').forEach(function (input) {
             const v = parseFloat(input.value);
-            if (!isNaN(v) && v > 0) {
-                input.value = roundWeight(convertWeight(v, currentUnit, unit));
-            }
+            if (!isNaN(v) && v > 0) input.value = roundWeight(convertWeight(v, currentUnit, unit));
         });
         currentUnit = unit;
         localStorage.setItem('weightUnit', currentUnit);
         applyUnitUI(document);
-        resetPlatePickers(); // plate denominations are physical — swap sets, don't convert
+        refreshPickers(); // denominations are physical — swap, don't convert
     };
 
     function applyUnitUI(root) {
         root = root || document;
-        root.querySelectorAll('.weight-unit-input').forEach(function (el) {
-            el.value = currentUnit;
-        });
-        root.querySelectorAll('.unit-display').forEach(function (el) {
-            el.textContent = currentUnit;
-        });
+        root.querySelectorAll('.weight-unit-input').forEach(function (el) { el.value = currentUnit; });
+        root.querySelectorAll('.unit-display').forEach(function (el) { el.textContent = currentUnit; });
         document.querySelectorAll('.unit-toggle-btn').forEach(function (btn) {
             btn.classList.toggle('active', btn.dataset.unit === currentUnit);
         });
         root.querySelectorAll('.last-set-badge').forEach(function (badge) {
-            const weightDisplay = badge.querySelector('.last-weight-display');
-            const unitLabel = badge.querySelector('.last-unit-label');
-            if (!weightDisplay || !unitLabel) return;
-            const rawValue = parseFloat(badge.dataset.lbsValue);
-            const storedUnit = badge.dataset.storedUnit || 'lbs';
-            if (isNaN(rawValue)) return;
-            weightDisplay.textContent = roundWeight(convertWeight(rawValue, storedUnit, currentUnit));
-            unitLabel.textContent = currentUnit;
+            const wd = badge.querySelector('.last-weight-display');
+            const ul = badge.querySelector('.last-unit-label');
+            if (!wd || !ul) return;
+            const raw = parseFloat(badge.dataset.lbsValue);
+            if (isNaN(raw)) return;
+            wd.textContent = roundWeight(convertWeight(raw, badge.dataset.storedUnit || 'lbs', currentUnit));
+            ul.textContent = currentUnit;
         });
     }
 
     function syncUnitInPanel(panel) {
-        panel.querySelectorAll('.weight-unit-input').forEach(function (el) {
-            el.value = currentUnit;
-        });
-        panel.querySelectorAll('.unit-display').forEach(function (el) {
-            el.textContent = currentUnit;
-        });
+        panel.querySelectorAll('.weight-unit-input').forEach(function (el) { el.value = currentUnit; });
+        panel.querySelectorAll('.unit-display').forEach(function (el) { el.textContent = currentUnit; });
     }
 
-    // Convert pre-filled weight inputs from stored unit to current preference
+    // Convert pre-filled weight inputs to saved unit preference on load
     document.querySelectorAll('.weight-input').forEach(function (input) {
-        const storedValue = parseFloat(input.dataset.storedValue);
-        const storedUnit = input.dataset.storedUnit || 'lbs';
-        if (!isNaN(storedValue) && storedValue > 0) {
-            input.value = roundWeight(convertWeight(storedValue, storedUnit, currentUnit));
-        }
+        const sv = parseFloat(input.dataset.storedValue);
+        const su = input.dataset.storedUnit || 'lbs';
+        if (!isNaN(sv) && sv > 0) input.value = roundWeight(convertWeight(sv, su, currentUnit));
     });
 
     applyUnitUI(document);

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -19,6 +19,12 @@ document.addEventListener('DOMContentLoaded', function () {
     const DB_LBS = [5, 7.5, 10, 12.5, 15, 17.5, 20, 22.5, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80];
     const DB_KG  = [4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 35, 37.5, 40];
     const PLATE_COLORS = ['#c0392b', '#2962a8', '#f1c40f', '#27ae60', '#7f8c8d', '#bdc3c7'];
+    // Mirrors the Jinja equipment_icon macro in _macros.html
+    const EQ_ICONS = {
+        barbell: '<svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor"><rect x="1" y="11" width="22" height="2" rx="1"/><rect x="4.5" y="7.5" width="2.4" height="9" rx="1"/><rect x="7.6" y="5.5" width="2.4" height="13" rx="1"/><rect x="17.1" y="7.5" width="2.4" height="9" rx="1"/><rect x="14" y="5.5" width="2.4" height="13" rx="1"/></svg>',
+        dumbbell: '<svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor"><rect x="8" y="11" width="8" height="2" rx="1"/><rect x="4" y="7" width="3" height="10" rx="1.2"/><rect x="17" y="7" width="3" height="10" rx="1.2"/><rect x="1.5" y="9" width="2" height="6" rx="1"/><rect x="20.5" y="9" width="2" height="6" rx="1"/></svg>',
+        machine: '<svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor"><rect x="6" y="5" width="12" height="3.2" rx="1"/><rect x="6" y="9.4" width="12" height="3.2" rx="1"/><rect x="6" y="13.8" width="12" height="3.2" rx="1"/><rect x="6" y="18.2" width="12" height="3.2" rx="1"/><rect x="11" y="1" width="2" height="5" rx="1"/></svg>',
+    };
 
     // ── Unit state ─────────────────────────────────────────────────
     let currentUnit = localStorage.getItem('weightUnit') || 'lbs';
@@ -31,6 +37,7 @@ document.addEventListener('DOMContentLoaded', function () {
     let openCardId = null;
 
     document.addEventListener('click', function (e) {
+        if (e.target.closest('.remove-exercise-form')) return;
         const header = e.target.closest('.exercise-card-header');
         if (!header) return;
         if (header.dataset.card) toggleCard(header.dataset.card);
@@ -75,6 +82,60 @@ document.addEventListener('DOMContentLoaded', function () {
         const icon = h.querySelector('.expand-icon');
         if (icon) icon.classList.toggle('open', open);
     }
+
+    // ── Routine edit mode ──────────────────────────────────────────
+    const editToggle = document.getElementById('edit-routine-toggle');
+    if (editToggle) {
+        editToggle.addEventListener('click', function () {
+            const container = document.querySelector('.routine-container');
+            const on = container.classList.toggle('edit-mode');
+            editToggle.classList.toggle('active', on);
+            editToggle.textContent = on ? '✓ Done' : '✎ Edit';
+        });
+    }
+
+    document.addEventListener('click', function (e) {
+        const t = e.target.closest('.add-exercise-toggle');
+        if (!t) return;
+        const box = t.parentElement.querySelector('.add-exercise-box');
+        if (box) box.hidden = !box.hidden;
+    });
+
+    // ── Add / remove sets ──────────────────────────────────────────
+    document.addEventListener('click', function (e) {
+        const addBtn = e.target.closest('[data-add-set]');
+        const remBtn = e.target.closest('[data-remove-set]');
+        if (!addBtn && !remBtn) return;
+
+        const form = e.target.closest('form');
+        const rows = form && form.querySelector('.set-rows');
+        if (!rows) return;
+        const count = rows.children.length;
+
+        if (remBtn) {
+            if (count > 1) rows.lastElementChild.remove();
+        } else {
+            if (count >= 10) return;
+            const i = count + 1;
+            const weighted = rows.dataset.weighted === '1';
+            const defaultReps = rows.dataset.defaultReps || '';
+            const row = mkEl('div', 'set-row');
+            let html = '<span class="set-label">Set ' + i + '</span><div class="set-inputs">';
+            if (weighted) {
+                html += '<div class="form-group"><label>Weight (<span class="unit-display">' + currentUnit + '</span>)</label>' +
+                        '<input type="number" class="weight-input" name="weight_set_' + i + '" step="0.5" min="0"></div>';
+            }
+            html += '<div class="form-group"><label>Reps</label>' +
+                    '<input type="number" name="reps_set_' + i + '" min="1" max="100" value="' + defaultReps + '"></div></div>';
+            row.innerHTML = html;
+            rows.appendChild(row);
+        }
+
+        // Rebuild the picker so Fill/Load buttons match the new set count
+        const panel = form.closest('.exercise-panel');
+        const picker = panel && panel.querySelector('.weight-picker');
+        if (picker) buildPicker(picker);
+    });
 
     // ── AJAX form submit ───────────────────────────────────────────
     document.addEventListener('submit', function (e) {
@@ -207,9 +268,10 @@ document.addEventListener('DOMContentLoaded', function () {
         // Header row
         const hdr = mkEl('div', 'picker-header');
         const title = mkEl('span', 'picker-title');
-        title.textContent = eq === 'barbell' ? 'Plate calculator'
-                          : eq === 'dumbbell' ? 'Dumbbell weight'
-                          : 'Quick fill';
+        const titleText = eq === 'barbell' ? 'Plate calculator'
+                        : eq === 'dumbbell' ? 'Dumbbell weight'
+                        : 'Quick fill';
+        title.innerHTML = (EQ_ICONS[eq] || '') + ' ' + titleText;
         hdr.appendChild(title);
         if (eq === 'barbell') {
             const tot = mkEl('span', 'picker-total');
@@ -234,7 +296,7 @@ document.addEventListener('DOMContentLoaded', function () {
             const b = mkEl('button', 'settings-opt-btn' + (t === eq ? ' active' : ''));
             b.type = 'button';
             b.dataset.setEquipment = t;
-            b.textContent = t.charAt(0).toUpperCase() + t.slice(1);
+            b.innerHTML = (EQ_ICONS[t] || '') + ' ' + t.charAt(0).toUpperCase() + t.slice(1);
             eqRow.appendChild(b);
         });
         sp.appendChild(eqRow);

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -269,15 +269,13 @@ document.addEventListener('DOMContentLoaded', function () {
         const hdr = mkEl('div', 'picker-header');
         const title = mkEl('span', 'picker-title');
         const titleText = eq === 'barbell' ? 'Plate calculator'
-                        : eq === 'dumbbell' ? 'Dumbbell weight'
-                        : 'Quick fill';
+                        : eq === 'dumbbell' ? 'Dumbbell rack'
+                        : 'Weight stack';
         title.innerHTML = (EQ_ICONS[eq] || '') + ' ' + titleText;
         hdr.appendChild(title);
-        if (eq === 'barbell') {
-            const tot = mkEl('span', 'picker-total');
-            tot.innerHTML = '<span class="picker-total-value"></span> <span class="unit-display picker-unit"></span>';
-            hdr.appendChild(tot);
-        }
+        const tot = mkEl('span', 'picker-total');
+        tot.innerHTML = '<span class="picker-total-value"></span> <span class="unit-display picker-unit"></span>';
+        hdr.appendChild(tot);
         const settingsBtn = mkEl('button', 'picker-settings-btn');
         settingsBtn.type = 'button';
         settingsBtn.textContent = '⚙';
@@ -314,6 +312,21 @@ document.addEventListener('DOMContentLoaded', function () {
                 bwRow.appendChild(b);
             });
             sp.appendChild(bwRow);
+        }
+        if (eq === 'machine') {
+            const ssRow = mkEl('div', 'settings-row');
+            const ssLabel = mkEl('span', 'settings-label');
+            ssLabel.textContent = 'Per plate:';
+            ssRow.appendChild(ssLabel);
+            const curStep = stackStep(p);
+            (currentUnit === 'kg' ? [2.5, 5, 7.5, 10] : [5, 10, 15, 20]).forEach(function (w) {
+                const b = mkEl('button', 'settings-opt-btn' + (w === curStep ? ' active' : ''));
+                b.type = 'button';
+                b.dataset.setStackStep = w;
+                b.textContent = fmtW(w) + ' ' + currentUnit;
+                ssRow.appendChild(b);
+            });
+            sp.appendChild(ssRow);
         }
         p.appendChild(sp);
 
@@ -372,38 +385,166 @@ document.addEventListener('DOMContentLoaded', function () {
         drawBarbell(p);
     }
 
+    function firstSetWeight(p) {
+        const inp = getSetInputs(p)[0];
+        const v = inp ? parseFloat(inp.value) : NaN;
+        return isNaN(v) || v <= 0 ? null : v;
+    }
+
+    function fillAllSets(p, w) {
+        getSetInputs(p).forEach(function (inp) {
+            inp.value = fmtW(w);
+            inp.classList.add('just-filled');
+            setTimeout(function () { inp.classList.remove('just-filled'); }, 500);
+        });
+    }
+
+    function nearestIndex(arr, value) {
+        let best = 0;
+        arr.forEach(function (w, i) {
+            if (Math.abs(w - value) < Math.abs(arr[best] - value)) best = i;
+        });
+        return best;
+    }
+
+    // ── Dumbbell: visual rack stepper ──
     function buildDumbbellContent(p) {
-        const steps = mkEl('div', 'db-steps');
-        curDbSteps().forEach(function (w) {
+        const steps = curDbSteps();
+        const w0 = firstSetWeight(p);
+        p._dbIndex = w0 != null ? nearestIndex(steps, w0) : Math.floor(steps.length / 3);
+
+        const vis = mkEl('div', 'dumbbell-visual');
+        const prev = mkEl('button', 'db-arrow');
+        prev.type = 'button';
+        prev.dataset.dbPrev = '1';
+        prev.textContent = '−';
+        const draw = mkEl('div', 'db-draw');
+        const next = mkEl('button', 'db-arrow');
+        next.type = 'button';
+        next.dataset.dbNext = '1';
+        next.textContent = '+';
+        vis.appendChild(prev);
+        vis.appendChild(draw);
+        vis.appendChild(next);
+        p.appendChild(vis);
+
+        const chips = mkEl('div', 'db-steps');
+        steps.forEach(function (w) {
             const b = mkEl('button', 'db-step-btn');
             b.type = 'button';
             b.dataset.dbWeight = w;
             b.textContent = fmtW(w);
-            steps.appendChild(b);
+            chips.appendChild(b);
         });
-        p.appendChild(steps);
+        p.appendChild(chips);
+
         const hint = mkEl('p', 'picker-hint');
-        hint.textContent = 'Tap a weight to fill all sets';
+        hint.textContent = 'Step through the rack — fills all sets';
         p.appendChild(hint);
+
+        renderDumbbell(p);
+    }
+
+    function renderDumbbell(p) {
+        const steps = curDbSteps();
+        p._dbIndex = Math.max(0, Math.min(p._dbIndex || 0, steps.length - 1));
+        const w = steps[p._dbIndex];
+        const ratio = (p._dbIndex + 1) / steps.length;
+
+        const draw = p.querySelector('.db-draw');
+        if (!draw) return;
+        draw.innerHTML = '';
+
+        const discs = 1 + Math.floor(ratio * 2.4); // 1–3 discs per side
+        const baseH = Math.round(26 + 34 * ratio);
+
+        function mkSide(reverse) {
+            const side = mkEl('div', 'db-side');
+            // Biggest disc closest to the handle
+            for (let i = 0; i < discs; i++) {
+                const d = mkEl('div', 'db-disc');
+                d.style.height = Math.max(16, baseH - i * 7) + 'px';
+                side.appendChild(d);
+            }
+            if (!reverse) {
+                // Mirror so the big disc faces the handle on both sides
+                Array.from(side.children).reverse().forEach(function (c) { side.appendChild(c); });
+            }
+            return side;
+        }
+
+        draw.appendChild(mkSide(false));
+        draw.appendChild(mkEl('div', 'db-handle'));
+        draw.appendChild(mkSide(true));
+
+        const lbl = mkEl('div', 'db-weight-label');
+        lbl.textContent = fmtW(w);
+        draw.appendChild(lbl);
+
+        p.querySelectorAll('.db-step-btn').forEach(function (b) {
+            b.classList.toggle('selected', parseFloat(b.dataset.dbWeight) === w);
+        });
+        const sel = p.querySelector('.db-step-btn.selected');
+        if (sel) {
+            const row = sel.parentElement;
+            row.scrollLeft = sel.offsetLeft - row.clientWidth / 2 + sel.clientWidth / 2;
+        }
+
+        const tv = p.querySelector('.picker-total-value');
+        if (tv) tv.textContent = fmtW(w);
+        p.querySelectorAll('.picker-unit').forEach(function (el) { el.textContent = currentUnit; });
+        return w;
+    }
+
+    // ── Machine: tap-the-pin weight stack ──
+    const STACK_PLATES = 15;
+
+    function stackStep(p) {
+        const pref = getExPref(p.dataset.exercise);
+        const saved = currentUnit === 'kg' ? pref.stackStepKg : pref.stackStepLbs;
+        return saved || (currentUnit === 'kg' ? 5 : 10);
     }
 
     function buildMachineContent(p) {
-        const step = currentUnit === 'kg' ? 2.5 : 5;
-        const row = mkEl('div', 'machine-stepper');
-        const minus = mkEl('button', 'stepper-btn');
-        minus.type = 'button';
-        minus.dataset.machineStep = -step;
-        minus.textContent = '−' + fmtW(step);
-        const lbl = mkEl('span', 'stepper-label');
-        lbl.textContent = 'Adjust all sets';
-        const plus = mkEl('button', 'stepper-btn');
-        plus.type = 'button';
-        plus.dataset.machineStep = step;
-        plus.textContent = '+' + fmtW(step);
-        row.appendChild(minus);
-        row.appendChild(lbl);
-        row.appendChild(plus);
-        p.appendChild(row);
+        const step = stackStep(p);
+        const w0 = firstSetWeight(p);
+        p._pin = w0 != null
+            ? Math.max(1, Math.min(STACK_PLATES, Math.round(w0 / step)))
+            : 5;
+
+        const wrap = mkEl('div', 'machine-visual');
+        const stack = mkEl('div', 'machine-stack');
+        for (let i = 1; i <= STACK_PLATES; i++) {
+            const plate = mkEl('button', 'stack-plate');
+            plate.type = 'button';
+            plate.dataset.pin = i;
+            const num = mkEl('span', 'stack-plate-num');
+            num.textContent = fmtW(i * step);
+            plate.appendChild(num);
+            stack.appendChild(plate);
+        }
+        wrap.appendChild(stack);
+        p.appendChild(wrap);
+
+        const hint = mkEl('p', 'picker-hint');
+        hint.textContent = 'Tap the stack to set the pin — fills all sets';
+        p.appendChild(hint);
+
+        renderStack(p);
+    }
+
+    function renderStack(p) {
+        const step = stackStep(p);
+        p.querySelectorAll('.stack-plate').forEach(function (plate) {
+            const i = parseInt(plate.dataset.pin, 10);
+            plate.classList.toggle('selected', i <= p._pin);
+            plate.classList.toggle('pinned', i === p._pin);
+        });
+        const total = p._pin * step;
+        const tv = p.querySelector('.picker-total-value');
+        if (tv) tv.textContent = fmtW(total);
+        p.querySelectorAll('.picker-unit').forEach(function (el) { el.textContent = currentUnit; });
+        return total;
     }
 
     function drawBarbell(p) {
@@ -538,22 +679,34 @@ document.addEventListener('DOMContentLoaded', function () {
             }
             return;
         }
-        // Machine stepper
-        const stepEl = e.target.closest('[data-machine-step]');
-        if (stepEl) {
-            const delta = parseFloat(stepEl.dataset.machineStep);
-            getSetInputs(p).forEach(function (inp) {
-                inp.value = fmtW(Math.max(0, (parseFloat(inp.value) || 0) + delta));
-            });
+        // Machine stack-step setting
+        const ssEl = e.target.closest('[data-set-stack-step]');
+        if (ssEl) {
+            const key = currentUnit === 'kg' ? 'stackStepKg' : 'stackStepLbs';
+            const patch = {};
+            patch[key] = parseFloat(ssEl.dataset.setStackStep);
+            setExPref(p.dataset.exercise, patch);
+            buildPicker(p);
             return;
         }
-        // Dumbbell weight select
+        // Machine: tap a plate to set the pin
+        const pinEl = e.target.closest('[data-pin]');
+        if (pinEl) {
+            p._pin = parseInt(pinEl.dataset.pin, 10);
+            fillAllSets(p, renderStack(p));
+            return;
+        }
+        // Dumbbell: step through the rack
+        if (e.target.closest('[data-db-prev]') || e.target.closest('[data-db-next]')) {
+            p._dbIndex = (p._dbIndex || 0) + (e.target.closest('[data-db-next]') ? 1 : -1);
+            fillAllSets(p, renderDumbbell(p));
+            return;
+        }
+        // Dumbbell: jump straight to a rack weight
         const dbEl = e.target.closest('[data-db-weight]');
         if (dbEl) {
-            p.querySelectorAll('[data-db-weight]').forEach(function (b) { b.classList.remove('selected'); });
-            dbEl.classList.add('selected');
-            const w = parseFloat(dbEl.dataset.dbWeight);
-            getSetInputs(p).forEach(function (inp) { inp.value = fmtW(w); });
+            p._dbIndex = curDbSteps().indexOf(parseFloat(dbEl.dataset.dbWeight));
+            fillAllSets(p, renderDumbbell(p));
         }
     });
 

--- a/app/templates/_macros.html
+++ b/app/templates/_macros.html
@@ -1,0 +1,9 @@
+{% macro equipment_icon(eq) -%}
+{%- if eq == 'barbell' -%}
+<svg viewBox="0 0 24 24" width="15" height="15" fill="currentColor" aria-label="barbell"><rect x="1" y="11" width="22" height="2" rx="1"/><rect x="4.5" y="7.5" width="2.4" height="9" rx="1"/><rect x="7.6" y="5.5" width="2.4" height="13" rx="1"/><rect x="17.1" y="7.5" width="2.4" height="9" rx="1"/><rect x="14" y="5.5" width="2.4" height="13" rx="1"/></svg>
+{%- elif eq == 'dumbbell' -%}
+<svg viewBox="0 0 24 24" width="15" height="15" fill="currentColor" aria-label="dumbbell"><rect x="8" y="11" width="8" height="2" rx="1"/><rect x="4" y="7" width="3" height="10" rx="1.2"/><rect x="17" y="7" width="3" height="10" rx="1.2"/><rect x="1.5" y="9" width="2" height="6" rx="1"/><rect x="20.5" y="9" width="2" height="6" rx="1"/></svg>
+{%- elif eq == 'machine' -%}
+<svg viewBox="0 0 24 24" width="15" height="15" fill="currentColor" aria-label="machine"><rect x="6" y="5" width="12" height="3.2" rx="1"/><rect x="6" y="9.4" width="12" height="3.2" rx="1"/><rect x="6" y="13.8" width="12" height="3.2" rx="1"/><rect x="6" y="18.2" width="12" height="3.2" rx="1"/><rect x="11" y="1" width="2" height="5" rx="1"/></svg>
+{%- endif -%}
+{%- endmacro %}

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% from "_macros.html" import equipment_icon %}
 {% block title %}{% if routine_type == 'gym' %}Gym Routine{% else %}BWF Routine{% endif %}{% endblock %}
 {% block content %}
 <div class="routine-container">
@@ -8,6 +9,9 @@
            class="routine-tab {% if routine_type == 'bwf' %}active{% endif %}">BWF</a>
         <a href="{{ url_for('main.home', routine='gym') }}"
            class="routine-tab {% if routine_type == 'gym' %}active{% endif %}">Gym</a>
+        {% if current_user.is_authenticated and routine_type == 'gym' %}
+        <button type="button" id="edit-routine-toggle" class="edit-routine-btn" title="Add or remove exercises">✎ Edit</button>
+        {% endif %}
     </div>
 
     {% if current_user.is_authenticated %}
@@ -16,11 +20,20 @@
             Workout in progress — tap an exercise to log it.
         </div>
         {% else %}
-        <div class="start-workout-cta">
-            <a href="{{ url_for('main.start_workout', routine_type=routine_type) }}" class="btn primary">
-                Start {% if routine_type == 'gym' %}Gym{% else %}BWF{% endif %} Workout
+        <div class="workout-launcher">
+            <p class="launcher-title">Ready to train?</p>
+            <a href="{{ url_for('main.start_workout', routine_type=routine_type) }}" class="btn primary launcher-btn">
+                ⚡ Start {% if routine_type == 'gym' %}Gym{% else %}BWF{% endif %} Workout
             </a>
+            <p class="launcher-hint">Showing your last-used routine — switch tabs to train the other.</p>
         </div>
+        {% endif %}
+
+        {% if routine_type == 'gym' and hidden_count %}
+        <form method="POST" action="{{ url_for('main.restore_exercises') }}" class="restore-form edit-only">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+            <button type="submit" class="restore-btn">↩ Restore {{ hidden_count }} removed exercise{{ 's' if hidden_count > 1 }}</button>
+        </form>
         {% endif %}
     {% endif %}
 
@@ -45,9 +58,12 @@
                     <div class="exercise-card-main">
                         <h3>{{ exercise.name }}</h3>
                         <div class="exercise-meta">
+                            {% if routine_type == 'gym' and exercise.get('equipment') and exercise.equipment != 'bodyweight' %}
+                            <span class="eq-icon" title="{{ exercise.equipment }}">{{ equipment_icon(exercise.equipment) }}</span>
+                            {% endif %}
                             <span>{{ exercise.sets }}×{{ exercise.reps }}</span>
-                            {% if exercise.get('weighted') %}
-                            <span class="weighted-badge">weighted</span>
+                            {% if exercise.get('custom') %}
+                            <span class="custom-badge">custom</span>
                             {% endif %}
                         </div>
 
@@ -64,7 +80,16 @@
                         <div class="exercise-last-reps">{{ last_log.reps_per_set }} reps</div>
                         {% endif %}
                     </div>
-                    <span class="expand-icon {% if can_log %}{% else %}nav-arrow{% endif %}">›</span>
+
+                    {% if current_user.is_authenticated and routine_type == 'gym' %}
+                    <form method="POST" action="{{ url_for('main.remove_exercise') }}" class="remove-exercise-form edit-only">
+                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                        <input type="hidden" name="name" value="{{ exercise.name }}">
+                        <button type="submit" class="remove-exercise-btn" title="Remove {{ exercise.name }}">×</button>
+                    </form>
+                    {% endif %}
+
+                    <span class="expand-icon {% if not can_log %}nav-arrow{% endif %}">›</span>
                 </div>
 
                 {% if can_log %}
@@ -100,9 +125,7 @@
                         <button type="button" class="unit-toggle-btn" data-unit="lbs" onclick="setUnit('lbs')">lbs</button>
                         <button type="button" class="unit-toggle-btn" data-unit="kg" onclick="setUnit('kg')">kg</button>
                     </div>
-                    {% endif %}
 
-                    {% if exercise.weighted %}
                     <div class="weight-picker"
                          data-exercise="{{ exercise.name }}"
                          data-default-equipment="{{ exercise.get('equipment', 'machine') }}">
@@ -120,30 +143,37 @@
                         <input type="hidden" class="weight-unit-input" name="weight_unit" value="lbs">
                         {% endif %}
 
-                        {% for i in range(1, num_sets + 1) %}
-                        <div class="set-row">
-                            <span class="set-label">Set {{ i }}</span>
-                            <div class="set-inputs">
-                                {% if exercise.weighted %}
-                                <div class="form-group">
-                                    <label>Weight (<span class="unit-display">lbs</span>)</label>
-                                    <input type="number" class="weight-input"
-                                           name="weight_set_{{ i }}"
-                                           step="0.5" min="0"
-                                           data-stored-value="{{ last_weights[i-1] if last_weights|length >= i else '' }}"
-                                           data-stored-unit="{{ last_unit }}"
-                                           value="{{ last_weights[i-1] if last_weights|length >= i else '' }}">
-                                </div>
-                                {% endif %}
-                                <div class="form-group">
-                                    <label>Reps</label>
-                                    <input type="number" name="reps_set_{{ i }}"
-                                           min="1" max="100"
-                                           value="{{ last_reps_list[i-1] if last_reps_list|length >= i else '' }}">
+                        <div class="set-rows" data-weighted="{{ 1 if exercise.weighted else 0 }}">
+                            {% for i in range(1, num_sets + 1) %}
+                            <div class="set-row">
+                                <span class="set-label">Set {{ i }}</span>
+                                <div class="set-inputs">
+                                    {% if exercise.weighted %}
+                                    <div class="form-group">
+                                        <label>Weight (<span class="unit-display">lbs</span>)</label>
+                                        <input type="number" class="weight-input"
+                                               name="weight_set_{{ i }}"
+                                               step="0.5" min="0"
+                                               data-stored-value="{{ last_weights[i-1] if last_weights|length >= i else '' }}"
+                                               data-stored-unit="{{ last_unit }}"
+                                               value="{{ last_weights[i-1] if last_weights|length >= i else '' }}">
+                                    </div>
+                                    {% endif %}
+                                    <div class="form-group">
+                                        <label>Reps</label>
+                                        <input type="number" name="reps_set_{{ i }}"
+                                               min="1" max="100"
+                                               value="{{ last_reps_list[i-1] if last_reps_list|length >= i else '' }}">
+                                    </div>
                                 </div>
                             </div>
+                            {% endfor %}
                         </div>
-                        {% endfor %}
+
+                        <div class="set-controls">
+                            <button type="button" class="set-ctrl-btn" data-remove-set>− set</button>
+                            <button type="button" class="set-ctrl-btn" data-add-set>+ set</button>
+                        </div>
 
                         <div class="form-error"></div>
                         <button type="submit" class="btn primary full-width">Log Exercise</button>
@@ -175,18 +205,25 @@
                         <input type="hidden" name="progression_level" value="{{ user_prog.current_progression }}">
                         {% endif %}
 
-                        {% for i in range(1, num_sets + 1) %}
-                        <div class="set-row">
-                            <span class="set-label">Set {{ i }}</span>
-                            <div class="set-inputs">
-                                <div class="form-group">
-                                    <label>Reps</label>
-                                    <input type="number" name="reps_set_{{ i }}"
-                                           min="1" max="30" value="{{ default_reps }}">
+                        <div class="set-rows" data-weighted="0" data-default-reps="{{ default_reps }}">
+                            {% for i in range(1, num_sets + 1) %}
+                            <div class="set-row">
+                                <span class="set-label">Set {{ i }}</span>
+                                <div class="set-inputs">
+                                    <div class="form-group">
+                                        <label>Reps</label>
+                                        <input type="number" name="reps_set_{{ i }}"
+                                               min="1" max="100" value="{{ default_reps }}">
+                                    </div>
                                 </div>
                             </div>
+                            {% endfor %}
                         </div>
-                        {% endfor %}
+
+                        <div class="set-controls">
+                            <button type="button" class="set-ctrl-btn" data-remove-set>− set</button>
+                            <button type="button" class="set-ctrl-btn" data-add-set>+ set</button>
+                        </div>
 
                         <div class="form-error"></div>
                         <button type="submit" class="btn primary full-width">Log Exercise</button>
@@ -199,6 +236,37 @@
             </li>
             {% endfor %}
         </ul>
+
+        {% if current_user.is_authenticated and routine_type == 'gym' %}
+        <div class="add-exercise-wrap edit-only">
+            <button type="button" class="add-exercise-toggle">+ Add exercise to {{ section }}</button>
+            <div class="add-exercise-box" hidden>
+                <form method="POST" action="{{ url_for('main.add_exercise') }}">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                    <input type="hidden" name="section" value="{{ section }}">
+                    <div class="form-group">
+                        <input type="text" name="name" placeholder="Exercise name" required maxlength="100">
+                    </div>
+                    <div class="add-ex-row">
+                        <input type="number" name="sets" value="3" min="1" max="10" class="add-ex-sets"> sets ×
+                        <input type="text" name="reps" value="8-12" maxlength="20" class="add-ex-reps"> reps
+                    </div>
+                    <div class="form-group">
+                        <select name="equipment">
+                            <option value="machine">Machine</option>
+                            <option value="dumbbell">Dumbbell</option>
+                            <option value="barbell">Barbell</option>
+                            <option value="bodyweight">Bodyweight</option>
+                        </select>
+                    </div>
+                    <div class="form-group">
+                        <textarea name="description" rows="2" placeholder="Notes / form cues (optional)" maxlength="500"></textarea>
+                    </div>
+                    <button type="submit" class="btn primary full-width">Add Exercise</button>
+                </form>
+            </div>
+        </div>
+        {% endif %}
     </section>
     {% endfor %}
 

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -102,6 +102,27 @@
                     </div>
                     {% endif %}
 
+                    {% if exercise.get('equipment') == 'barbell' %}
+                    <div class="plate-picker">
+                        <div class="plate-picker-header">
+                            <span class="plate-picker-title">Plate calculator</span>
+                            <span class="plate-total">
+                                <span class="plate-total-value">45</span>
+                                <span class="unit-display">lbs</span>
+                            </span>
+                        </div>
+                        <div class="barbell-visual"></div>
+                        <div class="plate-buttons"></div>
+                        <div class="plate-apply">
+                            <span class="plate-apply-label">Fill weight:</span>
+                            {% for i in range(1, num_sets + 1) %}
+                            <button type="button" class="plate-apply-btn" data-set="{{ i }}">Set {{ i }}</button>
+                            {% endfor %}
+                            <button type="button" class="plate-clear-btn">Clear</button>
+                        </div>
+                    </div>
+                    {% endif %}
+
                     <form class="exercise-log-form" method="POST"
                           action="{{ url_for('main.log_exercise', exercise_name=exercise.name) }}"
                           data-card-id="{{ card_id }}">

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -102,24 +102,10 @@
                     </div>
                     {% endif %}
 
-                    {% if exercise.get('equipment') == 'barbell' %}
-                    <div class="plate-picker">
-                        <div class="plate-picker-header">
-                            <span class="plate-picker-title">Plate calculator</span>
-                            <span class="plate-total">
-                                <span class="plate-total-value">45</span>
-                                <span class="unit-display">lbs</span>
-                            </span>
-                        </div>
-                        <div class="barbell-visual"></div>
-                        <div class="plate-buttons"></div>
-                        <div class="plate-apply">
-                            <span class="plate-apply-label">Fill weight:</span>
-                            {% for i in range(1, num_sets + 1) %}
-                            <button type="button" class="plate-apply-btn" data-set="{{ i }}">Set {{ i }}</button>
-                            {% endfor %}
-                            <button type="button" class="plate-clear-btn">Clear</button>
-                        </div>
+                    {% if exercise.weighted %}
+                    <div class="weight-picker"
+                         data-exercise="{{ exercise.name }}"
+                         data-default-equipment="{{ exercise.get('equipment', 'machine') }}">
                     </div>
                     {% endif %}
 

--- a/data/gym_routine.json
+++ b/data/gym_routine.json
@@ -5,6 +5,7 @@
       "sets": "3",
       "reps": "8-12",
       "weighted": true,
+      "equipment": "barbell",
       "description": "Barbell bench press. Lower to mid-chest with control, press back up without locking out."
     },
     {
@@ -12,6 +13,7 @@
       "sets": "3",
       "reps": "8-12",
       "weighted": true,
+      "equipment": "dumbbell",
       "description": "Dumbbell shoulder press. Keep core tight, press overhead without arching the lower back."
     },
     {
@@ -19,6 +21,7 @@
       "sets": "3",
       "reps": "10-12",
       "weighted": true,
+      "equipment": "machine",
       "description": "Cable tricep pushdown with rope. Keep elbows pinned at sides, extend fully and spread rope at the bottom."
     }
   ],
@@ -28,6 +31,7 @@
       "sets": "3",
       "reps": "8-12",
       "weighted": true,
+      "equipment": "machine",
       "description": "Wide grip lat pulldown. Pull bar to upper chest, squeeze lats at the bottom of the movement."
     },
     {
@@ -35,6 +39,7 @@
       "sets": "3",
       "reps": "8-12",
       "weighted": true,
+      "equipment": "dumbbell",
       "description": "Dumbbell bicep curls. Keep elbows pinned to sides, full range of motion, control the eccentric."
     },
     {
@@ -42,6 +47,7 @@
       "sets": "3",
       "reps": "8-12",
       "weighted": true,
+      "equipment": "machine",
       "description": "Cable seated row. Pull to lower chest, drive elbows back past body, squeeze shoulder blades together."
     }
   ],
@@ -51,6 +57,7 @@
       "sets": "3",
       "reps": "8-12",
       "weighted": true,
+      "equipment": "machine",
       "description": "Machine leg press. Full depth without knees caving, don't lock out at the top."
     },
     {
@@ -58,6 +65,7 @@
       "sets": "3",
       "reps": "10-12",
       "weighted": true,
+      "equipment": "machine",
       "description": "Machine leg extension. Slow eccentric, pause and squeeze quad at full extension."
     },
     {
@@ -65,6 +73,7 @@
       "sets": "3",
       "reps": "10-12",
       "weighted": true,
+      "equipment": "machine",
       "description": "Machine leg curl. Curl through full range of motion, control the return."
     },
     {
@@ -72,7 +81,8 @@
       "sets": "3",
       "reps": "12-15",
       "weighted": true,
-      "description": "Standing or seated calf raise. Full range — pause and stretch at the bottom, squeeze at the top."
+      "equipment": "machine",
+      "description": "Standing or seated calf raise. Full range \u2014 pause and stretch at the bottom, squeeze at the top."
     }
   ],
   "Core": [
@@ -81,6 +91,7 @@
       "sets": "3",
       "reps": "15-30",
       "weighted": false,
+      "equipment": "bodyweight",
       "description": "Standard crunches. Focus on contracting abs each rep, avoid pulling on your neck."
     }
   ]

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -116,6 +116,54 @@ def test_home_page_prefills_last_gym_log(logged_in_client):
     assert b'105' in resp.data
 
 
+def test_home_defaults_to_last_used_routine(logged_in_client):
+    client = logged_in_client
+    client.get('/start_workout?routine_type=gym')
+    client.get('/end_workout')
+
+    resp = client.get('/')  # no ?routine param
+    assert b'Bench Press' in resp.data
+
+
+def test_add_and_remove_custom_exercise(logged_in_client):
+    client = logged_in_client
+
+    resp = client.post('/routine/add_exercise', data={
+        'section': 'Push',
+        'name': 'Incline Press',
+        'sets': '4',
+        'reps': '8-10',
+        'equipment': 'dumbbell',
+    }, follow_redirects=True)
+    assert b'Incline Press' in resp.data
+    assert b'custom' in resp.data
+
+    resp = client.post('/routine/add_exercise', data={
+        'section': 'Push',
+        'name': 'Incline Press',
+        'equipment': 'dumbbell',
+    }, follow_redirects=True)
+    assert b'already in your routine' in resp.data
+
+    client.post('/routine/remove_exercise', data={'name': 'Incline Press'})
+    client.get('/?routine=gym')  # consume the "Removed ..." flash
+    resp = client.get('/?routine=gym')
+    assert b'Incline Press' not in resp.data
+
+
+def test_hide_and_restore_default_exercise(logged_in_client):
+    client = logged_in_client
+
+    client.post('/routine/remove_exercise', data={'name': 'Leg Curl'})
+    client.get('/?routine=gym')  # consume the "Removed ..." flash
+    resp = client.get('/?routine=gym')
+    assert b'Leg Curl' not in resp.data
+
+    client.post('/routine/restore_exercises', data={})
+    resp = client.get('/?routine=gym')
+    assert b'Leg Curl' in resp.data
+
+
 def test_weight_picker_on_all_weighted_exercises(logged_in_client):
     client = logged_in_client
     client.get('/start_workout?routine_type=gym')

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -114,3 +114,13 @@ def test_home_page_prefills_last_gym_log(logged_in_client):
     assert resp.status_code == 200
     assert b'Last session' in resp.data
     assert b'105' in resp.data
+
+
+def test_plate_picker_only_on_barbell_exercises(logged_in_client):
+    client = logged_in_client
+    client.get('/start_workout?routine_type=gym')
+
+    resp = client.get('/?routine=gym')
+    assert resp.status_code == 200
+    # Bench Press is the only barbell exercise in the gym routine
+    assert resp.data.count(b'Plate calculator') == 1

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -116,11 +116,15 @@ def test_home_page_prefills_last_gym_log(logged_in_client):
     assert b'105' in resp.data
 
 
-def test_plate_picker_only_on_barbell_exercises(logged_in_client):
+def test_weight_picker_on_all_weighted_exercises(logged_in_client):
     client = logged_in_client
     client.get('/start_workout?routine_type=gym')
 
     resp = client.get('/?routine=gym')
     assert resp.status_code == 200
-    # Bench Press is the only barbell exercise in the gym routine
-    assert resp.data.count(b'Plate calculator') == 1
+    # 10 weighted exercises (all gym exercises except Crunches) get a picker
+    assert resp.data.count(b'weight-picker') == 10
+    # Equipment defaults are encoded in data attributes
+    assert b'data-default-equipment="barbell"' in resp.data
+    assert b'data-default-equipment="dumbbell"' in resp.data
+    assert b'data-default-equipment="machine"' in resp.data


### PR DESCRIPTION
# Summary

This PR reworks the workout experience around one idea: **never leave the home page while training**. It also makes weight selection visual and fun, lets you customize the gym routine in-app, and lands a round of code-quality fixes (including two PostgreSQL deployment blockers).

## 🏋️ Inline logging (no page switches)

- Exercise cards expand in place during a workout — tap a card, log your sets, done. Only one card open at a time.
- Logging submits via AJAX; on success the card shows a "✓ 3 sets" badge and closes.
- **Fixed bottom timer bar** auto-starts when a set is logged (90s, 60s for core) with −30s / pause / +30s / reset controls and vibration on completion. Pinned to the thumb zone.
- The exercise detail page is now info-only (description + progression levels).

## ⚖️ Interactive weight pickers

Every weighted exercise gets a picker, with the equipment type remembered per exercise (overridable via ⚙ settings):

- **Barbell — plate calculator**: tap plates to load a drawn barbell (pairs, mirrored, heaviest at center, IPF-ish colors); tap a loaded plate to remove it. "Load from Set N" reverse-calculates the closest plate arrangement for a typed weight — handy for converting a machine weight to real plates. Bar weight configurable (45/35/25 lb, 20/15/10 kg).
- **Dumbbell — visual rack**: a drawn dumbbell that grows/shrinks as you step through rack weights with −/+ arrows, plus a swipeable chip row to jump anywhere. Fills all sets on selection.
- **Machine — pin stack**: tap a plate on a drawn 15-plate stack to set the pin, just like at the gym. Per-plate weight configurable per exercise (5–20 lb / 2.5–10 kg).
- **kg/lbs toggle** swaps physical denominations (and bar/stack steps) rather than converting them; typed weights still convert. Preference persists in localStorage.
- Pickers initialize from your last session's weight.

## ⚡ Quickstart + routine editing

- Home opens to your **last-used routine** with a one-tap "Ready to train? Start Workout" card.
- **✎ Edit mode** (gym): remove any exercise (built-ins are hidden, restorable; custom ones deleted) or add your own with name, sets × reps, equipment, and notes — stored per user in two new tables (`CustomExercise`, `HiddenExercise`, created automatically by `db.create_all()`).
- **Flexible sets**: +/− set buttons on every logging form (1–10); pickers rebuild to match.
- Inline SVG equipment icons (barbell/dumbbell/machine) on cards and pickers.

## 🔧 Code quality & deployment fixes

- **PostgreSQL blockers**: `password_hash` widened to 256 chars (werkzeug scrypt hashes are 162 — SQLite ignored the limit, Postgres won't); `db.create_all()` moved into `create_app()` so gunicorn creates tables (the `Procfile` never runs `run.py`).
- CSRF protection via Flask-WTF on all forms; minimum password length; `postgres://` URL normalization; `SECRET_KEY` warning when unset.
- `routes.py` refactored: gym/BWF logging split into helpers, progression advancement extracted and testable, legacy `Query.get()` / `datetime.utcnow` migrated.
- Removed dead `profile.html` and committed `.pyc` files; inline JS consolidated into `main.js`.
- New gym routine data (`gym_routine.json`) with per-exercise equipment types.
- README with local setup, testing, and Render + Neon deployment instructions.

## 🧪 Tests

20 tests (from zero): progression rules, set parsing, full register → login → workout → log → detail flow, permission checks, routine editing, quickstart default, and picker rendering.

```
======================== 20 passed in 3.29s ========================
```

## 📱 Notes for review

Everything is tuned for mobile (full-width buttons, 16px inputs to avoid iOS zoom, thumb-zone timer) but the picker visuals were built blind — the sandbox blocks headless-browser downloads, so no screenshots. Worth a quick visual pass on a phone before merging.

https://claude.ai/code/session_01189RwwfCxdMZtNQysXgmsY

---
_Generated by [Claude Code](https://claude.ai/code/session_01189RwwfCxdMZtNQysXgmsY)_