### PR TITLE
Rename app to NoFluff

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# BWF Routine App
+# NoFluff
 
-A mobile-friendly workout tracker built with Flask. Supports two built-in routines plus AI-generated ones:
+**The no fluff workout app.** A mobile-friendly workout tracker built with Flask — no ads, no upsells, no social feed. Supports two built-in routines plus AI-generated ones:
 
 - **BWF Routine** — the [Bodyweight Fitness Recommended Routine](https://www.reddit.com/r/bodyweightfitness/wiki/kb/recommended_routine/), with automatic progression tracking (e.g., scapular pulls → arch hangs → negative pull-ups → pull-ups)
 - **Gym Routine** — a machine/free-weight routine with per-set weight and rep logging
@@ -29,8 +29,8 @@ Flask 3 · Flask-SQLAlchemy · Flask-Login · Flask-WTF (CSRF) · Jinja2 · vani
 
 ```bash
 # 1. Clone and enter the repo
-git clone https://github.com/alexistats/bwf-routine-app.git
-cd bwf-routine-app
+git clone https://github.com/alexistats/nofluff.git
+cd nofluff
 
 # 2. Create a virtualenv and install dependencies
 python -m venv venv
@@ -41,13 +41,13 @@ pip install -r requirements.txt
 python run.py
 ```
 
-The app starts on `http://localhost:5000` with a local SQLite database (`bwf_routine.db`), created automatically on first run.
+The app starts on `http://localhost:5000` with a local SQLite database (`nofluff.db`), created automatically on first run.
 
 ### Configuration
 
 | Environment variable | Purpose | Default |
 |---|---|---|
-| `DATABASE_URL` | SQLAlchemy database URL (`postgres://` URLs are normalized automatically) | `sqlite:///bwf_routine.db` |
+| `DATABASE_URL` | SQLAlchemy database URL (`postgres://` URLs are normalized automatically) | `sqlite:///nofluff.db` |
 | `SECRET_KEY` | Flask session/CSRF signing key — **required in production** | insecure dev key (warns) |
 | `ANTHROPIC_API_KEY` | Shared Claude API key for the AI program generator — optional; users can also save their own key in Settings (stored encrypted, takes precedence) | unset (feature prompts for a user key) |
 

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -30,6 +30,13 @@ header {
 
 header h1 {
     font-size: 1.5rem;
+    margin-bottom: 0.1rem;
+}
+
+header .tagline {
+    font-size: 0.8rem;
+    color: #d7e3f2;
+    font-style: italic;
     margin-bottom: 0.5rem;
 }
 

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -4,14 +4,15 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="csrf-token" content="{{ csrf_token() }}">
-    <title>{% block title %}BWF Routine App{% endblock %}</title>
+    <title>{% block title %}NoFluff{% endblock %}</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
     {% block extra_css %}{% endblock %}
 </head>
 <body>
     <div class="container">
         <header>
-            <h1>BWF Recommended Routine</h1>
+            <h1>NoFluff</h1>
+            <p class="tagline">The no fluff workout app</p>
             <nav>
                 <a href="{{ url_for('main.home') }}">Home</a>
                 {% if current_user.is_authenticated %}
@@ -45,7 +46,7 @@
         </main>
 
         <footer>
-            <p>&copy; 2025 BWF Routine App</p>
+            <p>&copy; 2025 NoFluff</p>
         </footer>
     </div>
 

--- a/config.py
+++ b/config.py
@@ -12,7 +12,7 @@ class Config:
     # also store their own key in Settings, which takes precedence.
     ANTHROPIC_API_KEY = os.environ.get('ANTHROPIC_API_KEY')
 
-    _db_uri = os.environ.get('DATABASE_URL') or 'sqlite:///bwf_routine.db'
+    _db_uri = os.environ.get('DATABASE_URL') or 'sqlite:///nofluff.db'
     # SQLAlchemy 2.x requires 'postgresql://' — Render/Neon provide 'postgres://'
     if _db_uri.startswith('postgres://'):
         _db_uri = _db_uri.replace('postgres://', 'postgresql://', 1)


### PR DESCRIPTION
The app outgrew its BWF-only origins — it now covers gym routines and AI-generated programs. Rebrand as NoFluff ("the no fluff workout app"): page titles, header with tagline, footer, README, and the default SQLite filename (nofluff.db; existing local dev DBs keep their old name and would need a manual rename, production DATABASE_URL is unaffected).

https://claude.ai/code/session_01WXjJxCxGfxcfEsDmenGKhK