### PR TITLE
Fix AI generation worker timeouts and stale Postgres connections

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn "app:create_app()" --bind 0.0.0.0:$PORT
+web: gunicorn "app:create_app()" --bind 0.0.0.0:$PORT --timeout 300

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The app is set up for a free-tier deployment:
 1. **Neon** — create a free PostgreSQL project at [neon.tech](https://neon.tech) and copy the connection string
 2. **Render** — create a Web Service at [render.com](https://render.com) pointed at this repo (`main` branch):
    - Build command: `pip install -r requirements.txt`
-   - Start command: auto-detected from the `Procfile`
+   - Start command: `gunicorn "app:create_app()" --bind 0.0.0.0:$PORT --timeout 300` — set this explicitly in the dashboard (Render pre-fills a generic `gunicorn app:app` that won't work with this app's factory pattern; the `--timeout 300` gives AI program generation room to finish)
    - Python version: auto-detected from `.python-version` (don't set `PYTHON_VERSION` manually)
    - Environment variables: `DATABASE_URL` (Neon connection string) and `SECRET_KEY` (e.g., `python -c "import secrets; print(secrets.token_hex(32))"`)
 

--- a/app/ai_generator.py
+++ b/app/ai_generator.py
@@ -78,6 +78,10 @@ exercise selection toward the stated goal (e.g. grip/pull work for climbing, \
 posterior chain and intervals support for running)."""
 
 GENERATION_ERROR_HINTS = {
+    # APITimeoutError subclasses APIConnectionError — keep it first
+    anthropic.APITimeoutError:
+        'The coach took too long to respond. Try again — it usually works '
+        'on the second attempt.',
     anthropic.AuthenticationError:
         'The Claude API key was rejected. Check it in Settings.',
     anthropic.PermissionDeniedError:
@@ -131,7 +135,9 @@ def generate_program(api_key, inputs, previous_program=None, feedback=None):
                          f"Revise the program with this feedback: {feedback}\n"
                          "Keep everything that wasn't criticized."})
 
-    client = anthropic.Anthropic(api_key=api_key)
+    # Fail with a friendly message well before gunicorn's worker timeout
+    # (--timeout 300) would kill the request mid-flight.
+    client = anthropic.Anthropic(api_key=api_key, timeout=120.0, max_retries=1)
     last_error = None
     for _ in range(2):  # one automatic retry on invalid output
         try:
@@ -141,8 +147,13 @@ def generate_program(api_key, inputs, previous_program=None, feedback=None):
                 thinking={"type": "adaptive"},
                 system=SYSTEM_PROMPT,
                 messages=messages,
-                output_config={"format": {"type": "json_schema",
-                                          "schema": PROGRAM_SCHEMA}},
+                output_config={
+                    # medium effort keeps generation fast enough for a
+                    # synchronous web request without hurting program quality
+                    "effort": "medium",
+                    "format": {"type": "json_schema",
+                               "schema": PROGRAM_SCHEMA},
+                },
             )
         except anthropic.APIError as exc:
             for exc_type, hint in GENERATION_ERROR_HINTS.items():

--- a/config.py
+++ b/config.py
@@ -19,3 +19,11 @@ class Config:
     SQLALCHEMY_DATABASE_URI = _db_uri
 
     SQLALCHEMY_TRACK_MODIFICATIONS = False
+
+    # Neon (and Render's proxy) drop idle/stale connections, which surfaces as
+    # 'SSL error: decryption failed or bad record mac'. Verify connections
+    # before use and recycle them before the platform kills them.
+    SQLALCHEMY_ENGINE_OPTIONS = {
+        'pool_pre_ping': True,
+        'pool_recycle': 300,
+    }


### PR DESCRIPTION
## Summary

Fixes the two production errors seen after the first successful deploy: AI generation requests dying at ~60s, and the follow-up Postgres 500.

### Worker timeout during AI generation
- Gunicorn sync workers default to a 30s timeout — Claude program generation legitimately takes 30–90s, so the worker was SIGKILLed mid-request (`WORKER TIMEOUT` → `SIGKILL! Perhaps out of memory?` in the logs)
- `Procfile` now runs gunicorn with `--timeout 300`
- ⚠️ **Render uses the dashboard Start Command, not the Procfile** — after merging, update it to:
  ```
  gunicorn "app:create_app()" --bind 0.0.0.0:$PORT --timeout 300
  ```
- The Claude call itself is also faster and self-limiting now: `effort: medium` (meaningfully quicker generations with no real quality loss for workout programs) and a 120s client-side timeout, so a slow API returns a friendly "try again" flash message instead of a dead worker

### Stale Postgres connections (`SSL error: decryption failed or bad record mac`)
- Neon drops idle connections (and the worker kill corrupted a pooled one), producing the 500 on the next request
- Added `SQLALCHEMY_ENGINE_OPTIONS` with `pool_pre_ping: True` and `pool_recycle: 300` so connections are verified before use and recycled before the platform kills them

### Also
- README deployment section now spells out the exact Start Command (Render pre-fills a generic `gunicorn app:app` that doesn't work with this app's factory pattern)

## Test plan
- [x] `pytest` — 37 passed
- [ ] Merge, update the Render Start Command (above), redeploy
- [ ] Generate an AI program end-to-end on the live site — should complete without a worker timeout
- [ ] Browse a few pages afterwards to confirm no more `bad record mac` 500s

https://claude.ai/code/session_01WXjJxCxGfxcfEsDmenGKhK

---
_Generated by [Claude Code](https://claude.ai/code/session_01WXjJxCxGfxcfEsDmenGKhK)_